### PR TITLE
docs: ブランチ運用ルールを追加

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -21,6 +21,7 @@
 - `docs/dod.md`
 - `docs/test-policy.md`
 - `docs/release-migration-policy.md`
+- `docs/branch-strategy.md`
 - `docs/current-status.md`
 - `docs/backlog-priority.md`
 - `docs/known-issues.md`

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Phase 1 では以下を実装対象とします。
 - `docs/test-policy.md`: テスト方針
 - `docs/naming-conventions.md`: 命名規則
 - `docs/release-migration-policy.md`: 変更と移行の方針
+- `docs/branch-strategy.md`: ブランチ運用方針
 - `docs/adr/`: 重要な設計判断の記録
 - `docs/current-status.md`: 現在地
 - `docs/backlog-priority.md`: 優先順位

--- a/RULES.md
+++ b/RULES.md
@@ -120,6 +120,12 @@
 - `.env` はコミットしない
 - `.env.example` は常に最新に保つ
 - Git のコミットメッセージは日本語で記述する
+- 明示的な指示がない限り `main` へ直接 push しない
+- 基本運用は feature branch + Pull Request とする
+- release branch は明示的な指示がない限り切らない
+- バグ修正は `hotfix` として扱う
+- merge 方式は `merge commit` を使う
+- マージ済み branch は削除してよい
 
 ## Phase Rules
 

--- a/docs/branch-strategy.md
+++ b/docs/branch-strategy.md
@@ -1,0 +1,125 @@
+# Branch Strategy
+
+## Purpose
+
+このドキュメントは、このリポジトリにおける Git ブランチ運用ルールを定義する。
+
+## Basic Policy
+
+- 明示的な指示がない限り、`main` へ直接 push してはいけない
+- 基本運用は `feature branch + Pull Request` とする
+- 1 Issue につき 1 branch を基本とする
+
+## Main Branch Rules
+
+- `main` は統合ブランチとして扱う
+- `main` は常に安定状態を保つ
+- 通常の作業は `main` で直接行わない
+- 明示的に指示された場合のみ、`main` への直接 push を許可する
+
+## Branch Types
+
+### Feature Branch
+
+新機能追加や段階的な機能実装で使用する。
+
+例:
+
+- `feature/source-management`
+- `feature/csv-export`
+
+### Fix Branch
+
+通常の不具合修正で使用する。
+
+例:
+
+- `fix/article-filter`
+- `fix/frontend-detail-layout`
+
+### Hotfix Branch
+
+バグ修正は `hotfix` 扱いとする。
+
+例:
+
+- `hotfix/article-pagination`
+- `hotfix/collector-ingest-error`
+
+補足:
+
+- 本リポジトリでは、緊急性の有無にかかわらず、バグ修正系は `hotfix/*` を使ってよい
+
+### Docs Branch
+
+ドキュメント変更のみの場合に使用する。
+
+例:
+
+- `docs/api-guidelines-update`
+- `docs/rules-operations-update`
+
+### Chore Branch
+
+設定、テンプレート、補助タスクなどで使用する。
+
+例:
+
+- `chore/github-actions`
+- `chore/issue-templates`
+
+## Release Branch Policy
+
+- 明示的な指示がない限り、release branch は切らない
+- 通常は `main` を統合先として運用する
+
+## Pull Request Policy
+
+- `main` へ入れる変更は基本的に Pull Request 経由とする
+- PR では Issue と変更内容を対応づける
+- PR テンプレートに沿って影響範囲、検証、docs 更新有無を明記する
+
+## Merge Policy
+
+- merge 方式は `merge commit` を使用する
+- `squash merge` は標準運用にしない
+- `rebase merge` は標準運用にしない
+
+理由:
+
+- 履歴上で branch 単位のまとまりを残しやすくするため
+
+## Branch Deletion Policy
+
+- マージ済み branch は削除してよい
+- 未マージ branch は削除前に必要性を確認する
+- 長期間放置した branch は、Issue や current status を見て整理する
+
+## Recommended Workflow
+
+1. `main` を最新化する
+2. Issue に対応する branch を切る
+3. 実装する
+4. `make verify` を実行する
+5. Pull Request を作成する
+6. `main` に merge commit で取り込む
+7. マージ済み branch を削除する
+
+## Naming Rules
+
+- ブランチ名は小文字とハイフンを基本にする
+- 種別プレフィックスを付ける
+- 内容が分かる短い名前にする
+
+使用する主なプレフィックス:
+
+- `feature/`
+- `fix/`
+- `hotfix/`
+- `docs/`
+- `chore/`
+
+## Exceptions
+
+- 明示的な指示がある場合は、その指示を優先する
+- 緊急対応で `main` へ直接対応が必要な場合も、明示的な指示が必要

--- a/docs/naming-conventions.md
+++ b/docs/naming-conventions.md
@@ -122,11 +122,13 @@
 ### Branch
 
 - 目的が分かる短い名前
+- 詳細なブランチ運用は `docs/branch-strategy.md` を参照する
 
 例:
 
 - `feature/source-management`
 - `feature/csv-export`
+- `hotfix/article-filter`
 - `fix/article-filter`
 - `docs/rules-update`
 

--- a/docs/rules-operations.md
+++ b/docs/rules-operations.md
@@ -17,6 +17,7 @@
 - `docs/test-policy.md`
 - `docs/naming-conventions.md`
 - `docs/release-migration-policy.md`
+- `docs/branch-strategy.md`
 - `docs/adr/*`
 - `docs/current-status.md`
 - `docs/backlog-priority.md`
@@ -51,6 +52,7 @@
 - `docs/test-policy.md` はテスト追加判断基準
 - `docs/naming-conventions.md` は命名の基準
 - `docs/release-migration-policy.md` は変更の安全な進め方
+- `docs/branch-strategy.md` は Git 運用の基準
 - `docs/adr/*` は設計判断の理由
 - `docs/current-status.md` は次セッションの入口
 - `docs/backlog-priority.md` は優先順の固定
@@ -69,6 +71,7 @@
 - `RULES.md`
 - `docs/current-status.md`
 - `docs/backlog-priority.md`
+- `docs/branch-strategy.md`
 - 今回の変更に関係する guideline
 
 例:
@@ -185,6 +188,16 @@
 
 - 破壊的変更の扱い変更
 - リリース / 移行の進め方変更
+
+### branch-strategy.md を更新する場合
+
+以下のような変更時に更新する。
+
+- main 運用ルール変更
+- PR 必須ルール変更
+- merge 方式変更
+- branch 種別変更
+- branch 削除ルール変更
 
 ### ADR を追加する場合
 
@@ -309,12 +322,13 @@ Issue 作成時は、ルールや要件に関係する背景を記載する。
 推奨運用手順:
 
 1. Issue を作る
-2. 影響範囲を確認する
-3. 対応する rule / guideline を読む
-4. 実装する
-5. 必要な docs を更新する
-6. `make verify` を実行する
-7. PR を作る
+2. branch を切る
+3. 影響範囲を確認する
+4. 対応する rule / guideline を読む
+5. 実装する
+6. 必要な docs を更新する
+7. `make verify` を実行する
+8. PR を作る
 
 ## Session Continuity Rules
 
@@ -327,6 +341,7 @@ Issue 作成時は、ルールや要件に関係する背景を記載する。
 - 大きな変更は `CHANGELOG.md` に残す
 - 標準検証は `make verify` を使う
 - コミットメッセージ規約は `docs/naming-conventions.md` を参照し、日本語で記述する
+- Git 運用は `docs/branch-strategy.md` を参照する
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- ブランチ戦略を  として追加
-  直 push 禁止、feature branch + PR、release branch 非採用、hotfix、merge commit、マージ済み branch 削除ルールを明文化
- 関連するルール文書と入口ドキュメントを更新

## Why
- セッションが変わっても Git 運用ルールがぶれないようにするため
-  直運用を避け、今後の変更を PR ベースに統一するため

## Changes
-  を追加
-  に Git 運用ルールを反映
- , , ,  を更新

## Scope
- docs

## Verification
- [ ] FAIL	./... [setup failed]
FAIL
- [ ] 
- [ ] 
- [x] 文書間の整合を確認

## API / DB / Infra Impact
- [x] No major impact

## Documentation
- [x] Updated relevant docs in 
- [x] Updated 

## Risks
- 実装影響はなく、ドキュメント運用ルールのみの変更

## Notes
- 今後は明示的な指示がない限り  へ直接 push しない運用とする