### PR TITLE
ci: GitHub Actions と main 保護設定を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  verify:
+    name: verify
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Verify repository
+        run: make verify

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - GitHub Issue / PR テンプレート
 - Current status / backlog priority / known issues / glossary
 - Makefile の `build`, `test`, `verify` タスク
+- GitHub Actions の最小 CI workflow
+- collector-service / api-gateway の最小テスト
 
 ## 0.1.0
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-include .env
+-include .env
 
 .PHONY: up down logs ps build test verify
 

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -23,12 +23,15 @@
 - Docker Compose 起動基盤
 - ルール / 要件 / ガイドライン / ADR のドキュメント群
 - GitHub Issue / PR テンプレート
+- GitHub Actions の最小 CI
+- collector-service / api-gateway の最小ユニットテスト
 
 ## Verified State
 
 - Go サービスの `go test ./...` は通過済み
 - frontend の `npm run build` は通過済み
 - `docker compose config -q` は通過済み
+- `make verify` は通過済み
 
 ## Highest Priority Next
 

--- a/services/api-gateway/internal/httpapi/routes_test.go
+++ b/services/api-gateway/internal/httpapi/routes_test.go
@@ -1,0 +1,76 @@
+package httpapi
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestProxyGetForwardsQueryAndBody(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.Path != "/api/v1/articles" {
+				t.Fatalf("unexpected path: %s", req.URL.Path)
+			}
+			if got := req.URL.Query().Get("q"); got != "kubernetes" {
+				t.Fatalf("unexpected query: %s", got)
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"items":[],"total":0}`)),
+			}, nil
+		}),
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/articles?q=kubernetes", nil)
+
+	proxyGet(c, client, "http://article-service/api/v1/articles")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status code: got=%d want=%d", rec.Code, http.StatusOK)
+	}
+	if body := rec.Body.String(); body != `{"items":[],"total":0}` {
+		t.Fatalf("unexpected body: %s", body)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("unexpected content type: %s", got)
+	}
+}
+
+func TestProxyGetReturnsBadGatewayOnTransportError(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return nil, io.EOF
+		}),
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/articles", nil)
+
+	proxyGet(c, client, "http://article-service/api/v1/articles")
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("unexpected status code: got=%d want=%d", rec.Code, http.StatusBadGateway)
+	}
+}

--- a/services/collector-service/internal/collector/service_test.go
+++ b/services/collector-service/internal/collector/service_test.go
@@ -1,0 +1,48 @@
+package collector
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParsePubDate(t *testing.T) {
+	t.Parallel()
+
+	got, err := parsePubDate("Mon, 02 Jan 2006 15:04:05 +0900")
+	if err != nil {
+		t.Fatalf("parsePubDate returned error: %v", err)
+	}
+
+	want := time.Date(2006, 1, 2, 6, 4, 5, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Fatalf("unexpected parsed time: got=%s want=%s", got, want)
+	}
+}
+
+func TestParsePubDateReturnsErrorForUnsupportedLayout(t *testing.T) {
+	t.Parallel()
+
+	if _, err := parsePubDate("2026/04/14 12:00:00"); err == nil {
+		t.Fatal("expected error for unsupported layout")
+	}
+}
+
+func TestDedupeKeyTrimsWhitespace(t *testing.T) {
+	t.Parallel()
+
+	left := dedupeKey(" https://example.com/articles/1 ")
+	right := dedupeKey("https://example.com/articles/1")
+	if left != right {
+		t.Fatalf("dedupe key should ignore surrounding whitespace: left=%s right=%s", left, right)
+	}
+}
+
+func TestStripHTMLNormalizesText(t *testing.T) {
+	t.Parallel()
+
+	got := stripHTML("<p>Hello&nbsp;World</p><br />A &amp; B")
+	want := "Hello World A & B"
+	if got != want {
+		t.Fatalf("unexpected stripped text: got=%q want=%q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- GitHub Actions で make verify を実行する CI workflow を追加
- collector-service と api-gateway に最小テストを追加
- current status と changelog を更新
- main ブランチに PR 必須 / verify 必須 / 直接 push 抑止の保護設定を適用

## Why
- セッションが変わっても最低限の品質を自動で担保するため
- main への直接変更を防ぎ、PR ベースの運用へ統一するため

## Changes
- .github/workflows/ci.yml を追加
- services/api-gateway/internal/httpapi/routes_test.go を追加
- services/collector-service/internal/collector/service_test.go を追加
- docs/current-status.md と CHANGELOG.md を更新

## Scope
- api-gateway
- collector-service
- .github
- docs

## Verification
- [x] make verify
- [x] GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./... (api-gateway)
- [x] GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./... (collector-service)

## API / DB / Infra Impact
- [x] No major API change
- [x] No DB schema change
- [x] GitHub Actions / branch protection added

## Documentation
- [x] Updated docs/current-status.md
- [x] Updated CHANGELOG.md

## Risks
- branch protection now blocks direct pushes to main and requires the verify check
- PR workflow must stay green to merge

## Notes
- main branch protection was applied via GitHub API with required status check context verify and required pull request reviews enabled
