### PR TITLE
ci: docs-only 変更時の CI を軽量化し PR テンプレートを日本語化

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,16 @@
-## Summary
+## 概要
 
 - 
 
-## Why
+## 背景 / 目的
 
 - 
 
-## Changes
+## 変更内容
 
 - 
 
-## Scope
+## 影響範囲
 
 - frontend
 - api-gateway
@@ -20,31 +20,31 @@
 - infra
 - docs
 
-## Verification
+## 検証
 
 - [ ] `go test ./...`
 - [ ] `npm run build`
 - [ ] `docker compose config -q`
-- [ ] Other:
+- [ ] その他:
 
-## API / DB / Infra Impact
+## API / DB / Infra への影響
 
-- [ ] API changed
-- [ ] DB schema changed
-- [ ] Compose changed
-- [ ] Kubernetes / Helm changed
-- [ ] No major impact
+- [ ] API を変更した
+- [ ] DB schema を変更した
+- [ ] Compose を変更した
+- [ ] Kubernetes / Helm を変更した
+- [ ] 大きな影響はない
 
-## Documentation
+## ドキュメント
 
-- [ ] Updated `RULES.md` if needed
-- [ ] Updated relevant docs in `docs/`
-- [ ] No doc changes needed
+- [ ] 必要に応じて `RULES.md` を更新した
+- [ ] 関連する `docs/` を更新した
+- [ ] ドキュメント更新は不要
 
-## Risks
+## リスク / 注意点
 
 - 
 
-## Notes
+## 補足
 
 - 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,44 @@ on:
   workflow_dispatch:
 
 jobs:
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.filter.outputs.docs == 'true' && steps.filter.outputs.code != 'true' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+              - '**/*.md'
+              - '.github/ISSUE_TEMPLATE/**'
+              - '.github/pull_request_template.md'
+              - 'CHANGELOG.md'
+              - 'CODEOWNERS'
+            code:
+              - '.github/workflows/**'
+              - 'frontend/**'
+              - 'services/**'
+              - 'deployments/**'
+              - 'docker-compose.yml'
+              - 'Makefile'
+              - '.env.example'
+              - '.dockerignore'
+              - '.gitignore'
+              - 'package*.json'
+
   verify:
     name: verify
     runs-on: ubuntu-latest
+    needs: changes
 
     steps:
       - name: Checkout
@@ -22,6 +57,7 @@ jobs:
           go-version: "1.24"
 
       - name: Setup Node.js
+        if: needs.changes.outputs.docs_only != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: "22"
@@ -29,8 +65,14 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install frontend dependencies
+        if: needs.changes.outputs.docs_only != 'true'
         working-directory: frontend
         run: npm ci
 
       - name: Verify repository
+        if: needs.changes.outputs.docs_only != 'true'
         run: make verify
+
+      - name: Skip heavy verification for docs-only changes
+        if: needs.changes.outputs.docs_only == 'true'
+        run: echo "docs-only change detected; skipping make verify"


### PR DESCRIPTION
## 概要
- PR テンプレートを日本語化
- docs-only 変更では重い make verify を走らせないよう CI を調整
- ただし branch protection 用の verify コンテキストは維持し、docs-only の場合は no-op 成功を返す

## 背景 / 目的
- PR 記述を日本語運用へ揃えるため
- ドキュメント修正だけで重い検証を回さないようにして開発効率を上げるため
- 既存の main 保護設定と両立させるため

## 変更内容
- .github/pull_request_template.md を日本語化
- .github/workflows/ci.yml に docs-only 判定ジョブを追加
- docs-only の場合は verify ジョブで no-op 成功、コード変更時のみ make verify を実行

## 影響範囲
- .github
- docs 運用

## 検証
- [x] workflow 内容を確認
- [x] PR テンプレート内容を確認
- [ ] GitHub Actions 上で docs-only / code change の両ケース確認

## API / DB / Infra への影響
- [ ] API を変更した
- [ ] DB schema を変更した
- [ ] Compose を変更した
- [ ] Kubernetes / Helm を変更した
- [x] 大きな影響はない

## ドキュメント
- [ ] 必要に応じて RULES.md を更新した
- [ ] 関連する docs/ を更新した
- [x] ドキュメント更新は不要

## リスク / 注意点
- docs-only 判定対象に含めるパスの見直しは今後必要になる可能性がある

## 補足
- required status check は引き続き verify のまま維持する
