### PR TITLE
docs: CI 軽量化ルールの説明を追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,8 @@ Phase 1 では以下を実装対象とします。
 - `make build`: frontend build
 - `make test`: backend test
 - `make verify`: test + build + compose config check
+
+補足:
+
+- 通常のコード変更では CI も `make verify` 相当を実行します
+- docs-only 変更では、GitHub Actions は required check を維持しつつ重い検証を省略します

--- a/docs/rules-operations.md
+++ b/docs/rules-operations.md
@@ -105,6 +105,13 @@
 - ドキュメント更新漏れがないか
 - `docs/dod.md` を満たしているか
 
+### CI Interpretation
+
+- 通常のコード変更では `make verify` を回す
+- docs-only 変更では、required status check を壊さない範囲で重い検証を省略してよい
+- その場合でも `verify` チェック自体は成功状態を返す
+- docs-only 判定ロジックは `.github/workflows/ci.yml` を正本とする
+
 ## Update Policy
 
 ### RULES.md を更新する場合
@@ -342,6 +349,7 @@ Issue 作成時は、ルールや要件に関係する背景を記載する。
 - 標準検証は `make verify` を使う
 - コミットメッセージ規約は `docs/naming-conventions.md` を参照し、日本語で記述する
 - Git 運用は `docs/branch-strategy.md` を参照する
+- docs-only 変更時の CI 軽量化ルールは `.github/workflows/ci.yml` と `docs/test-policy.md` を参照する
 
 ## Notes
 

--- a/docs/test-policy.md
+++ b/docs/test-policy.md
@@ -111,6 +111,13 @@
 - frontend build
 - compose config validation
 
+補足:
+
+- 通常のコード変更では上記を `make verify` で実行する
+- docs-only 変更では、required status check を維持するため `verify` ジョブは成功させる
+- ただし docs-only 変更時は重い `make verify` を省略してよい
+- docs-only 判定条件は workflow 側で管理する
+
 将来的に追加候補:
 
 - API integration test


### PR DESCRIPTION
## 概要
- docs-only 変更時の CI 軽量化ルールを文書へ反映
- test policy / rules operations / README の説明を CI 実装に合わせて整合

## 背景 / 目的
- 実際の GitHub Actions 挙動とドキュメント説明のずれを解消するため
- 次のセッションでも docs-only の扱いを誤解しないようにするため

## 変更内容
- docs/test-policy.md を更新
- docs/rules-operations.md を更新
- README.md を更新

## 影響範囲
- docs

## 検証
- [x] 変更差分を確認
- [x] CI 実装との整合を確認
- [ ] GitHub Actions 上で docs-only PR の verify 成功確認

## API / DB / Infra への影響
- [ ] API を変更した
- [ ] DB schema を変更した
- [ ] Compose を変更した
- [ ] Kubernetes / Helm を変更した
- [x] 大きな影響はない

## ドキュメント
- [ ] 必要に応じて RULES.md を更新した
- [x] 関連する docs/ を更新した
- [ ] ドキュメント更新は不要

## リスク / 注意点
- docs-only 判定対象の変更時は workflow と docs の両方を更新する必要がある

## 補足
- PR #11 はすでにマージ済みのため、本PRで説明の追補のみを行う
