### PR TITLE
feat: add fetch job history visibility

### DIFF
--- a/deployments/compose/mysql/init/001_schema.sql
+++ b/deployments/compose/mysql/init/001_schema.sql
@@ -48,5 +48,6 @@ CREATE TABLE IF NOT EXISTS fetch_jobs (
   duplicated_count INT NOT NULL DEFAULT 0,
   error_message TEXT NULL,
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_fetch_jobs_source_status_started (source_id, status, started_at, id),
   CONSTRAINT fk_fetch_jobs_source_id FOREIGN KEY (source_id) REFERENCES sources(id)
 );

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -27,6 +27,7 @@
 - `collector-service` の最小 RSS 収集フロー
 - `frontend` の記事一覧 / 詳細 / 検索画面
 - `frontend` のソース一覧 / 作成 / 編集 / 有効無効切り替え画面
+- `frontend` の source 詳細と取得ジョブ履歴確認画面
 - MySQL 初期スキーマ
 - Docker Compose 起動基盤
 - ルール / 要件 / ガイドライン / ADR のドキュメント群
@@ -43,10 +44,10 @@
 
 ## Highest Priority Next
 
-1. 取得ジョブ履歴と失敗状況の可視化
-2. 既読 / お気に入り管理
-3. CSV 出力
-4. collector-service のソース管理連携
+1. 既読 / お気に入り管理
+2. CSV 出力
+3. collector-service のソース管理連携
+4. notification-service と RabbitMQ 連携
 
 ## Open GitHub Issues
 
@@ -60,7 +61,7 @@
 
 ## Known Gaps
 
-- ソース管理 UI/API は実装済みだが、collector-service はまだ静的設定依存
+- ソース管理 UI/API とジョブ履歴 UI/API は実装済みだが、collector-service はまだ静的設定依存
 - 認証は未実装
 - 既読 / お気に入りは未実装
 - CSV 出力は未実装

--- a/docs/db-guidelines.md
+++ b/docs/db-guidelines.md
@@ -58,6 +58,7 @@
 `articles.category`
 `articles.dedupe_key`
 `fetch_jobs.source_id`
+`fetch_jobs.source_id + status + started_at`
 `sources.name`
 
 - 過剰に index を貼りすぎない

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -11,6 +11,7 @@
 - 現在の collector-service は環境変数ベースのソース定義を使用している
 - ソース管理 API / UI はあるが、collector-service とはまだ接続されていない
 - アプリ上の source 作成・編集・有効無効切り替えは収集対象へ自動反映されない
+- 取得ジョブ履歴と失敗状況の可視化はできるが、収集対象自体の同期は未実装
 - Phase 2 の後続対応で collector 側連携が必要
 
 ### Authentication Is Not Implemented

--- a/docs/openapi/api-gateway.yaml
+++ b/docs/openapi/api-gateway.yaml
@@ -148,6 +148,42 @@ paths:
           description: Source not found
         "409":
           description: Source still referenced
+  /api/v1/fetch-jobs:
+    get:
+      summary: List fetch jobs for a source
+      parameters:
+        - in: query
+          name: source_id
+          required: true
+          schema:
+            type: integer
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum:
+              - running
+              - success
+              - failed
+        - in: query
+          name: page
+          schema:
+            type: integer
+            default: 1
+        - in: query
+          name: page_size
+          schema:
+            type: integer
+            default: 20
+      responses:
+        "200":
+          description: Fetch job list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListFetchJobsResponse"
+        "400":
+          description: Validation error
 components:
   schemas:
     Source:
@@ -233,3 +269,61 @@ components:
         - interval_minutes
         - default_category
         - is_enabled
+    FetchJob:
+      type: object
+      properties:
+        id:
+          type: integer
+        source_id:
+          type: integer
+        started_at:
+          type: string
+          format: date-time
+        finished_at:
+          type: string
+          format: date-time
+          nullable: true
+        status:
+          type: string
+          enum:
+            - running
+            - success
+            - failed
+        fetched_count:
+          type: integer
+        inserted_count:
+          type: integer
+        duplicated_count:
+          type: integer
+        error_message:
+          type: string
+          nullable: true
+      required:
+        - id
+        - source_id
+        - started_at
+        - status
+        - fetched_count
+        - inserted_count
+        - duplicated_count
+    ListFetchJobsResponse:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/FetchJob"
+        total:
+          type: integer
+        page:
+          type: integer
+        page_size:
+          type: integer
+        total_pages:
+          type: integer
+      required:
+        - items
+        - total
+        - page
+        - page_size
+        - total_pages

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -91,6 +91,7 @@ docker compose config -q
 - `article-service` の `/internal/ingest` が生きているか
 - dedupe / DB 制約で失敗していないか
 - fetch_jobs と source status が更新されているか
+- UI では `/sources/:id` のジョブ履歴画面で失敗メッセージを確認できるか
 
 ### CSV Export Mismatch
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -56,6 +56,26 @@ export type SourceInput = {
   is_enabled: boolean;
 };
 
+export type FetchJob = {
+  id: number;
+  source_id: number;
+  started_at: string;
+  finished_at: string | null;
+  status: "running" | "success" | "failed";
+  fetched_count: number;
+  inserted_count: number;
+  duplicated_count: number;
+  error_message: string | null;
+};
+
+export type ListFetchJobsResponse = {
+  items: FetchJob[];
+  total: number;
+  page: number;
+  page_size: number;
+  total_pages: number;
+};
+
 export async function fetchArticles(params: {
   q?: string;
   category?: string;
@@ -73,6 +93,21 @@ export async function fetchArticle(id: string) {
 export async function fetchSources() {
   const response = await api.get<{ items: Source[] }>("/api/v1/sources");
   return response.data.items;
+}
+
+export async function fetchSource(id: string | number) {
+  const response = await api.get<Source>(`/api/v1/sources/${id}`);
+  return response.data;
+}
+
+export async function fetchFetchJobs(params: {
+  source_id: number;
+  status?: "running" | "success" | "failed";
+  page?: number;
+  page_size?: number;
+}) {
+  const response = await api.get<ListFetchJobsResponse>("/api/v1/fetch-jobs", { params });
+  return response.data;
 }
 
 export async function createSource(input: SourceInput) {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,7 @@ import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import { AppLayout } from "./ui/AppLayout";
 import { ArticleDetailPage } from "./ui/ArticleDetailPage";
 import { ArticleListPage } from "./ui/ArticleListPage";
+import { SourceDetailPage } from "./ui/SourceDetailPage";
 import { SourceManagementPage } from "./ui/SourceManagementPage";
 import "./styles.css";
 
@@ -16,6 +17,7 @@ const router = createBrowserRouter([
       { index: true, element: <ArticleListPage /> },
       { path: "articles/:id", element: <ArticleDetailPage /> },
       { path: "sources", element: <SourceManagementPage /> },
+      { path: "sources/:id", element: <SourceDetailPage /> },
     ],
   },
 ]);

--- a/frontend/src/ui/SourceDetailPage.tsx
+++ b/frontend/src/ui/SourceDetailPage.tsx
@@ -1,0 +1,261 @@
+import { useQuery } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+import { useState, type ReactNode } from "react";
+import { Link, useParams } from "react-router-dom";
+import { fetchFetchJobs, fetchSource, type FetchJob, type Source } from "../lib/api";
+
+const pageSize = 10;
+
+export function SourceDetailPage() {
+  const params = useParams();
+  const [status, setStatus] = useState<"all" | "success" | "failed" | "running">("all");
+  const [page, setPage] = useState(1);
+
+  const sourceId = Number(params.id);
+  const isValidSourceID = Number.isInteger(sourceId) && sourceId > 0;
+
+  const sourceQuery = useQuery({
+    queryKey: ["source", sourceId],
+    queryFn: () => fetchSource(sourceId),
+    enabled: isValidSourceID,
+  });
+
+  const jobsQuery = useQuery({
+    queryKey: ["fetch-jobs", sourceId, status, page],
+    queryFn: () =>
+      fetchFetchJobs({
+        source_id: sourceId,
+        status: status === "all" ? undefined : status,
+        page,
+        page_size: pageSize,
+      }),
+    enabled: isValidSourceID,
+  });
+
+  if (!isValidSourceID) {
+    return <ErrorMessage message="Invalid source id" />;
+  }
+
+  return (
+    <div className="space-y-8">
+      <section className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-2xl shadow-slate-950/40">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="space-y-2">
+            <p className="text-sm uppercase tracking-[0.35em] text-cyan-300">Source Detail</p>
+            <h1 className="text-4xl font-semibold tracking-tight text-white">
+              {sourceQuery.data?.name ?? "Loading source"}
+            </h1>
+            <p className="max-w-3xl text-sm leading-6 text-slate-300">
+              最終取得結果とジョブ履歴を確認します。失敗の原因はここで先に把握し、collector のログ確認は補助的に使います。
+            </p>
+          </div>
+          <Link
+            to="/sources"
+            className="rounded-full border border-cyan-300/40 px-4 py-2 text-sm text-cyan-200 transition hover:border-cyan-200 hover:text-white"
+          >
+            Back to Sources
+          </Link>
+        </div>
+      </section>
+
+      {sourceQuery.isLoading ? <PanelMessage>Loading source...</PanelMessage> : null}
+      {sourceQuery.isError ? <ErrorMessage message={getErrorMessage(sourceQuery.error)} /> : null}
+
+      {sourceQuery.data ? <SourceOverview source={sourceQuery.data} /> : null}
+
+      <section className="rounded-3xl border border-white/10 bg-slate-950/60 p-6">
+        <div className="mb-5 flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h2 className="text-xl font-semibold text-white">Fetch Job History</h2>
+            <p className="mt-2 text-sm text-slate-400">
+              {jobsQuery.data?.total ?? 0} jobs / page {jobsQuery.data?.page ?? page}
+            </p>
+          </div>
+          <label className="flex items-center gap-3 text-sm text-slate-300">
+            <span>Status</span>
+            <select
+              value={status}
+              onChange={(event) => {
+                setStatus(event.target.value as "all" | "success" | "failed" | "running");
+                setPage(1);
+              }}
+              className="rounded-2xl border border-white/10 bg-slate-900 px-4 py-3 text-sm text-white outline-none"
+            >
+              <option value="all">all</option>
+              <option value="success">success</option>
+              <option value="failed">failed</option>
+              <option value="running">running</option>
+            </select>
+          </label>
+        </div>
+
+        {jobsQuery.isLoading ? <PanelMessage>Loading fetch jobs...</PanelMessage> : null}
+        {jobsQuery.isError ? <ErrorMessage message={getErrorMessage(jobsQuery.error)} /> : null}
+        {!jobsQuery.isLoading && jobsQuery.data?.items.length === 0 ? (
+          <PanelMessage>No fetch jobs matched the current filter.</PanelMessage>
+        ) : null}
+
+        {jobsQuery.data?.items.length ? (
+          <div className="space-y-4">
+            {jobsQuery.data.items.map((job) => (
+              <FetchJobCard key={job.id} job={job} />
+            ))}
+
+            <div className="flex flex-wrap items-center justify-between gap-3 border-t border-white/10 pt-4">
+              <p className="text-sm text-slate-400">
+                Page {jobsQuery.data.page} / {Math.max(jobsQuery.data.total_pages, 1)}
+              </p>
+              <div className="flex gap-3">
+                <button
+                  type="button"
+                  onClick={() => setPage((current) => Math.max(current - 1, 1))}
+                  disabled={page <= 1}
+                  className="rounded-2xl border border-white/10 px-4 py-2 text-sm text-slate-200 transition hover:border-white/20 hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  Previous
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setPage((current) => current + 1)}
+                  disabled={jobsQuery.data.page >= jobsQuery.data.total_pages}
+                  className="rounded-2xl border border-white/10 px-4 py-2 text-sm text-slate-200 transition hover:border-white/20 hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          </div>
+        ) : null}
+      </section>
+    </div>
+  );
+}
+
+function SourceOverview(props: { source: Source }) {
+  const { source } = props;
+
+  return (
+    <section className="grid gap-6 lg:grid-cols-[1.1fr,0.9fr]">
+      <article className="rounded-3xl border border-white/10 bg-slate-900/70 p-6">
+        <h2 className="mb-4 text-xl font-semibold text-white">Source Overview</h2>
+        <dl className="grid gap-4 text-sm text-slate-300">
+          <DetailRow label="Name" value={source.name} />
+          <DetailRow label="Type" value={`${source.type} / ${source.fetch_method}`} />
+          <DetailRow label="Interval" value={`every ${source.interval_minutes} minutes`} />
+          <DetailRow label="Category" value={source.default_category} />
+          <DetailRow label="Status" value={source.is_enabled ? "enabled" : "disabled"} />
+          <DetailRow label="Fetch URL" value={source.fetch_url} />
+        </dl>
+      </article>
+
+      <article className="rounded-3xl border border-white/10 bg-slate-900/70 p-6">
+        <h2 className="mb-4 text-xl font-semibold text-white">Latest Result</h2>
+        <div className="space-y-4 text-sm text-slate-300">
+          <div className="flex flex-wrap gap-2">
+            <span className={`rounded-full px-3 py-1 text-xs font-medium ${statusBadgeClass(source.last_fetch_status)}`}>
+              {source.last_fetch_status ?? "never"}
+            </span>
+            <span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">
+              Last fetch: {formatDate(source.last_fetched_at)}
+            </span>
+          </div>
+          <p className="leading-6 text-slate-300">
+            {source.last_error_message ?? "最新のエラーメッセージはありません。"}
+          </p>
+        </div>
+      </article>
+    </section>
+  );
+}
+
+function FetchJobCard(props: { job: FetchJob }) {
+  const { job } = props;
+
+  return (
+    <article className="rounded-3xl border border-white/10 bg-slate-900/70 p-5">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <span className={`rounded-full px-3 py-1 text-xs font-medium ${statusBadgeClass(job.status)}`}>{job.status}</span>
+          <span className="text-sm text-slate-400">Job #{job.id}</span>
+        </div>
+        <p className="text-sm text-slate-400">
+          {formatDate(job.started_at)} - {formatDate(job.finished_at)}
+        </p>
+      </div>
+
+      <div className="mb-3 grid gap-3 text-sm text-slate-300 md:grid-cols-3">
+        <StatBox label="Fetched" value={String(job.fetched_count)} />
+        <StatBox label="Inserted" value={String(job.inserted_count)} />
+        <StatBox label="Duplicated" value={String(job.duplicated_count)} />
+      </div>
+
+      {job.error_message ? (
+        <div className="rounded-2xl border border-rose-400/30 bg-rose-950/30 p-3 text-sm text-rose-200">
+          {job.error_message}
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+function DetailRow(props: { label: string; value: string }) {
+  return (
+    <div className="grid gap-1">
+      <dt className="text-xs uppercase tracking-[0.25em] text-slate-500">{props.label}</dt>
+      <dd className="break-all text-sm text-slate-200">{props.value}</dd>
+    </div>
+  );
+}
+
+function StatBox(props: { label: string; value: string }) {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+      <p className="text-xs uppercase tracking-[0.25em] text-slate-500">{props.label}</p>
+      <p className="mt-2 text-lg font-semibold text-white">{props.value}</p>
+    </div>
+  );
+}
+
+function PanelMessage(props: { children: ReactNode }) {
+  return <div className="rounded-2xl border border-white/10 bg-white/5 p-6 text-sm text-slate-300">{props.children}</div>;
+}
+
+function ErrorMessage(props: { message: string }) {
+  return <div className="rounded-2xl border border-rose-400/30 bg-rose-950/40 p-4 text-sm text-rose-200">{props.message}</div>;
+}
+
+function formatDate(value: string | null) {
+  if (!value) {
+    return "not finished";
+  }
+  return new Intl.DateTimeFormat("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+function statusBadgeClass(status: string | null) {
+  switch (status) {
+    case "success":
+      return "bg-emerald-400/15 text-emerald-200";
+    case "failed":
+      return "bg-rose-400/15 text-rose-200";
+    case "running":
+      return "bg-amber-400/15 text-amber-200";
+    default:
+      return "bg-slate-700 text-slate-200";
+  }
+}
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof AxiosError) {
+    return error.response?.data?.error ?? error.message;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return "Unknown error";
+}

--- a/frontend/src/ui/SourceManagementPage.tsx
+++ b/frontend/src/ui/SourceManagementPage.tsx
@@ -4,6 +4,7 @@ import { AxiosError } from "axios";
 import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import { useForm } from "react-hook-form";
+import { Link } from "react-router-dom";
 import { z } from "zod";
 import { createSource, fetchSources, Source, SourceInput, updateSource } from "../lib/api";
 
@@ -187,6 +188,12 @@ export function SourceManagementPage() {
                   >
                     Edit Source
                   </button>
+                  <Link
+                    to={`/sources/${source.id}`}
+                    className="ml-4 text-sm font-medium text-amber-300 transition hover:text-amber-100"
+                  >
+                    View History
+                  </Link>
                 </article>
               );
             })}

--- a/services/api-gateway/internal/httpapi/routes.go
+++ b/services/api-gateway/internal/httpapi/routes.go
@@ -33,6 +33,10 @@ func RegisterRoutes(router *gin.Engine, articleServiceURL string) {
 			targetURL := articleServiceURL + "/api/v1/sources/" + c.Param("id")
 			proxyRequest(c, client, targetURL)
 		})
+		v1.GET("/fetch-jobs", func(c *gin.Context) {
+			targetURL := articleServiceURL + "/api/v1/fetch-jobs"
+			proxyRequest(c, client, targetURL)
+		})
 		v1.POST("/sources", func(c *gin.Context) {
 			targetURL := articleServiceURL + "/api/v1/sources"
 			proxyRequest(c, client, targetURL)

--- a/services/api-gateway/internal/httpapi/routes_test.go
+++ b/services/api-gateway/internal/httpapi/routes_test.go
@@ -121,3 +121,38 @@ func TestProxyRequestForwardsMethodHeadersAndBody(t *testing.T) {
 		t.Fatalf("unexpected body: %s", body)
 	}
 }
+
+func TestProxyRequestForwardsFetchJobsQuery(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.Path != "/api/v1/fetch-jobs" {
+				t.Fatalf("unexpected path: %s", req.URL.Path)
+			}
+			if got := req.URL.Query().Get("source_id"); got != "7" {
+				t.Fatalf("unexpected source_id: %s", got)
+			}
+			if got := req.URL.Query().Get("status"); got != "failed" {
+				t.Fatalf("unexpected status: %s", got)
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"items":[],"total":0,"page":1,"page_size":20,"total_pages":0}`)),
+			}, nil
+		}),
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/fetch-jobs?source_id=7&status=failed", nil)
+
+	proxyRequest(c, client, "http://article-service/api/v1/fetch-jobs")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status code: got=%d want=%d", rec.Code, http.StatusOK)
+	}
+}

--- a/services/article-service/internal/domain/models.go
+++ b/services/article-service/internal/domain/models.go
@@ -48,6 +48,21 @@ type FetchJob struct {
 	ErrorMessage    *string    `json:"error_message"`
 }
 
+type ListFetchJobsParams struct {
+	SourceID int64
+	Status   string
+	Page     int
+	PageSize int
+}
+
+type ListFetchJobsResult struct {
+	Items      []FetchJob `json:"items"`
+	Total      int        `json:"total"`
+	Page       int        `json:"page"`
+	PageSize   int        `json:"page_size"`
+	TotalPages int        `json:"total_pages"`
+}
+
 type ListArticlesParams struct {
 	Query    string
 	Category string

--- a/services/article-service/internal/httpapi/router.go
+++ b/services/article-service/internal/httpapi/router.go
@@ -90,6 +90,25 @@ func NewRouter(db *sql.DB, articleService *service.ArticleService) *gin.Engine {
 			c.JSON(http.StatusOK, source)
 		})
 
+		v1.GET("/fetch-jobs", func(c *gin.Context) {
+			sourceID, _ := strconv.ParseInt(c.Query("source_id"), 10, 64)
+			page, _ := strconv.Atoi(defaultString(c.Query("page"), "1"))
+			pageSize, _ := strconv.Atoi(defaultString(c.Query("page_size"), "20"))
+
+			result, err := articleService.ListFetchJobs(c.Request.Context(), domain.ListFetchJobsParams{
+				SourceID: sourceID,
+				Status:   c.Query("status"),
+				Page:     page,
+				PageSize: pageSize,
+			})
+			if err != nil {
+				writeServiceError(c, err)
+				return
+			}
+
+			c.JSON(http.StatusOK, result)
+		})
+
 		v1.POST("/sources", func(c *gin.Context) {
 			var req service.SourceInput
 			if err := c.ShouldBindJSON(&req); err != nil {
@@ -141,6 +160,40 @@ func NewRouter(db *sql.DB, articleService *service.ArticleService) *gin.Engine {
 
 	internal := router.Group("/internal")
 	{
+		internal.POST("/fetch-jobs/start", func(c *gin.Context) {
+			var req service.StartFetchJobInput
+			if err := c.ShouldBindJSON(&req); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			}
+
+			result, err := articleService.StartFetchJob(c.Request.Context(), req)
+			if err != nil {
+				writeServiceError(c, err)
+				return
+			}
+			c.JSON(http.StatusAccepted, result)
+		})
+
+		internal.POST("/fetch-jobs/:id/finish", func(c *gin.Context) {
+			jobID, err := parseIDParam(c, "fetch job id")
+			if err != nil {
+				return
+			}
+
+			var req service.FinishFetchJobInput
+			if err := c.ShouldBindJSON(&req); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			}
+
+			if err := articleService.FinishFetchJob(c.Request.Context(), jobID, req); err != nil {
+				writeServiceError(c, err)
+				return
+			}
+			c.Status(http.StatusNoContent)
+		})
+
 		internal.POST("/ingest", func(c *gin.Context) {
 			var req service.IngestRequest
 			if err := c.ShouldBindJSON(&req); err != nil {

--- a/services/article-service/internal/repository/fetch_job_repository.go
+++ b/services/article-service/internal/repository/fetch_job_repository.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math"
+	"strings"
 	"time"
+
+	"tech-feed-hub/article-service/internal/domain"
 )
 
 type FetchJobRepository struct {
@@ -26,6 +30,88 @@ func (r *FetchJobRepository) Create(ctx context.Context, sourceID int64) (int64,
 	return id, nil
 }
 
+func (r *FetchJobRepository) GetByID(ctx context.Context, id int64) (*domain.FetchJob, error) {
+	row := r.db.QueryRowContext(ctx, `
+		SELECT id, source_id, started_at, finished_at, status, fetched_count, inserted_count, duplicated_count, error_message
+		FROM fetch_jobs
+		WHERE id = ?`, id)
+
+	job, err := scanFetchJob(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get fetch job: %w", err)
+	}
+	return &job, nil
+}
+
+func (r *FetchJobRepository) List(ctx context.Context, params domain.ListFetchJobsParams) (domain.ListFetchJobsResult, error) {
+	if params.Page < 1 {
+		params.Page = 1
+	}
+	if params.PageSize < 1 || params.PageSize > 100 {
+		params.PageSize = 20
+	}
+
+	where := []string{"1=1"}
+	args := make([]any, 0, 2)
+	if params.SourceID > 0 {
+		where = append(where, "source_id = ?")
+		args = append(args, params.SourceID)
+	}
+	if params.Status != "" {
+		where = append(where, "status = ?")
+		args = append(args, params.Status)
+	}
+
+	whereClause := strings.Join(where, " AND ")
+	countQuery := fmt.Sprintf("SELECT COUNT(*) FROM fetch_jobs WHERE %s", whereClause)
+	var total int
+	if err := r.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
+		return domain.ListFetchJobsResult{}, fmt.Errorf("count fetch jobs: %w", err)
+	}
+
+	offset := (params.Page - 1) * params.PageSize
+	listQuery := fmt.Sprintf(`
+		SELECT id, source_id, started_at, finished_at, status, fetched_count, inserted_count, duplicated_count, error_message
+		FROM fetch_jobs
+		WHERE %s
+		ORDER BY started_at DESC, id DESC
+		LIMIT ? OFFSET ?`, whereClause)
+	listArgs := append(append([]any{}, args...), params.PageSize, offset)
+	rows, err := r.db.QueryContext(ctx, listQuery, listArgs...)
+	if err != nil {
+		return domain.ListFetchJobsResult{}, fmt.Errorf("list fetch jobs: %w", err)
+	}
+	defer rows.Close()
+
+	items := make([]domain.FetchJob, 0)
+	for rows.Next() {
+		job, err := scanFetchJob(rows)
+		if err != nil {
+			return domain.ListFetchJobsResult{}, err
+		}
+		items = append(items, job)
+	}
+	if err := rows.Err(); err != nil {
+		return domain.ListFetchJobsResult{}, fmt.Errorf("iterate fetch jobs: %w", err)
+	}
+
+	totalPages := 0
+	if total > 0 {
+		totalPages = int(math.Ceil(float64(total) / float64(params.PageSize)))
+	}
+
+	return domain.ListFetchJobsResult{
+		Items:      items,
+		Total:      total,
+		Page:       params.Page,
+		PageSize:   params.PageSize,
+		TotalPages: totalPages,
+	}, nil
+}
+
 func (r *FetchJobRepository) Finish(ctx context.Context, jobID int64, status string, fetchedCount int, insertedCount int, duplicatedCount int, errMsg *string) error {
 	_, err := r.db.ExecContext(ctx, `
 		UPDATE fetch_jobs
@@ -43,4 +129,34 @@ func (r *FetchJobRepository) Finish(ctx context.Context, jobID int64, status str
 		return fmt.Errorf("finish fetch job: %w", err)
 	}
 	return nil
+}
+
+func scanFetchJob(scanner interface {
+	Scan(dest ...any) error
+}) (domain.FetchJob, error) {
+	var job domain.FetchJob
+	var finishedAt sql.NullTime
+	var errorMessage sql.NullString
+
+	if err := scanner.Scan(
+		&job.ID,
+		&job.SourceID,
+		&job.StartedAt,
+		&finishedAt,
+		&job.Status,
+		&job.FetchedCount,
+		&job.InsertedCount,
+		&job.DuplicatedCount,
+		&errorMessage,
+	); err != nil {
+		return domain.FetchJob{}, err
+	}
+
+	if finishedAt.Valid {
+		job.FinishedAt = &finishedAt.Time
+	}
+	if errorMessage.Valid {
+		job.ErrorMessage = &errorMessage.String
+	}
+	return job, nil
 }

--- a/services/article-service/internal/service/article_service.go
+++ b/services/article-service/internal/service/article_service.go
@@ -32,9 +32,32 @@ func (e *serviceError) Unwrap() error {
 }
 
 type ArticleService struct {
-	articleRepo *repository.ArticleRepository
-	sourceRepo  *repository.SourceRepository
-	jobRepo     *repository.FetchJobRepository
+	articleRepo articleRepository
+	sourceRepo  sourceRepository
+	jobRepo     fetchJobRepository
+}
+
+type articleRepository interface {
+	List(ctx context.Context, params domain.ListArticlesParams) (domain.ListArticlesResult, error)
+	GetByID(ctx context.Context, id int64) (*domain.Article, error)
+	BulkUpsert(ctx context.Context, sourceID int64, articles []domain.Article) (inserted int, duplicated int, err error)
+}
+
+type sourceRepository interface {
+	List(ctx context.Context) ([]domain.Source, error)
+	GetByID(ctx context.Context, id int64) (*domain.Source, error)
+	Create(ctx context.Context, source domain.Source) (*domain.Source, error)
+	Update(ctx context.Context, source domain.Source) (*domain.Source, error)
+	Delete(ctx context.Context, id int64) (bool, error)
+	EnsureSource(ctx context.Context, source domain.Source) (int64, error)
+	UpdateFetchStatus(ctx context.Context, id int64, status string, errMsg *string) error
+}
+
+type fetchJobRepository interface {
+	Create(ctx context.Context, sourceID int64) (int64, error)
+	GetByID(ctx context.Context, id int64) (*domain.FetchJob, error)
+	List(ctx context.Context, params domain.ListFetchJobsParams) (domain.ListFetchJobsResult, error)
+	Finish(ctx context.Context, jobID int64, status string, fetchedCount int, insertedCount int, duplicatedCount int, errMsg *string) error
 }
 
 func NewArticleService(articleRepo *repository.ArticleRepository, sourceRepo *repository.SourceRepository, jobRepo *repository.FetchJobRepository) *ArticleService {
@@ -43,6 +66,16 @@ func NewArticleService(articleRepo *repository.ArticleRepository, sourceRepo *re
 		sourceRepo:  sourceRepo,
 		jobRepo:     jobRepo,
 	}
+}
+
+func (s *ArticleService) ListFetchJobs(ctx context.Context, params domain.ListFetchJobsParams) (domain.ListFetchJobsResult, error) {
+	if params.SourceID < 1 {
+		return domain.ListFetchJobsResult{}, newServiceError(ErrValidation, "source_id is required")
+	}
+	if params.Status != "" && params.Status != "running" && params.Status != "success" && params.Status != "failed" {
+		return domain.ListFetchJobsResult{}, newServiceError(ErrValidation, "status must be running, success, or failed")
+	}
+	return s.jobRepo.List(ctx, params)
 }
 
 func (s *ArticleService) ListArticles(ctx context.Context, params domain.ListArticlesParams) (domain.ListArticlesResult, error) {
@@ -139,6 +172,8 @@ type IngestArticleInput struct {
 }
 
 type IngestRequest struct {
+	JobID    int64                `json:"job_id"`
+	SourceID int64                `json:"source_id"`
 	Source   IngestSourceInput    `json:"source"`
 	Articles []IngestArticleInput `json:"articles"`
 }
@@ -152,21 +187,25 @@ type IngestResult struct {
 }
 
 func (s *ArticleService) Ingest(ctx context.Context, req IngestRequest) (IngestResult, error) {
-	sourceID, err := s.sourceRepo.EnsureSource(ctx, domain.Source{
-		Name:            req.Source.Name,
-		Type:            req.Source.Type,
-		FetchURL:        req.Source.FetchURL,
-		FetchMethod:     req.Source.FetchMethod,
-		IntervalMinutes: req.Source.IntervalMinutes,
-		DefaultCategory: req.Source.DefaultCategory,
-	})
+	if req.JobID < 1 {
+		return IngestResult{}, newServiceError(ErrValidation, "job_id is required")
+	}
+	if req.SourceID < 1 {
+		return IngestResult{}, newServiceError(ErrValidation, "source_id is required")
+	}
+
+	job, err := s.jobRepo.GetByID(ctx, req.JobID)
 	if err != nil {
 		return IngestResult{}, err
 	}
-
-	jobID, err := s.jobRepo.Create(ctx, sourceID)
-	if err != nil {
-		return IngestResult{}, err
+	if job == nil {
+		return IngestResult{}, newServiceError(ErrNotFound, "fetch job not found")
+	}
+	if job.SourceID != req.SourceID {
+		return IngestResult{}, newServiceError(ErrValidation, "job source mismatch")
+	}
+	if job.Status != "running" {
+		return IngestResult{}, newServiceError(ErrConflict, "fetch job is already finished")
 	}
 
 	articles := make([]domain.Article, 0, len(req.Articles))
@@ -188,28 +227,98 @@ func (s *ArticleService) Ingest(ctx context.Context, req IngestRequest) (IngestR
 		})
 	}
 
-	inserted, duplicated, ingestErr := s.articleRepo.BulkUpsert(ctx, sourceID, articles)
+	inserted, duplicated, ingestErr := s.articleRepo.BulkUpsert(ctx, req.SourceID, articles)
 	if ingestErr != nil {
-		errMsg := ingestErr.Error()
-		_ = s.jobRepo.Finish(ctx, jobID, "failed", len(articles), inserted, duplicated, &errMsg)
-		_ = s.sourceRepo.UpdateFetchStatus(ctx, sourceID, "failed", &errMsg)
 		return IngestResult{}, fmt.Errorf("bulk upsert: %w", ingestErr)
 	}
 
-	if err := s.jobRepo.Finish(ctx, jobID, "success", len(articles), inserted, duplicated, nil); err != nil {
-		return IngestResult{}, err
-	}
-	if err := s.sourceRepo.UpdateFetchStatus(ctx, sourceID, "success", nil); err != nil {
-		return IngestResult{}, err
-	}
-
 	return IngestResult{
-		SourceID:        sourceID,
-		JobID:           jobID,
+		SourceID:        req.SourceID,
+		JobID:           req.JobID,
 		FetchedCount:    len(articles),
 		InsertedCount:   inserted,
 		DuplicatedCount: duplicated,
 	}, nil
+}
+
+type StartFetchJobInput struct {
+	Source IngestSourceInput `json:"source"`
+}
+
+type StartFetchJobResult struct {
+	SourceID int64 `json:"source_id"`
+	JobID    int64 `json:"job_id"`
+}
+
+func (s *ArticleService) StartFetchJob(ctx context.Context, input StartFetchJobInput) (StartFetchJobResult, error) {
+	sourceID, err := s.sourceRepo.EnsureSource(ctx, domain.Source{
+		Name:            input.Source.Name,
+		Type:            input.Source.Type,
+		FetchURL:        input.Source.FetchURL,
+		FetchMethod:     input.Source.FetchMethod,
+		IntervalMinutes: input.Source.IntervalMinutes,
+		DefaultCategory: input.Source.DefaultCategory,
+	})
+	if err != nil {
+		return StartFetchJobResult{}, err
+	}
+
+	jobID, err := s.jobRepo.Create(ctx, sourceID)
+	if err != nil {
+		return StartFetchJobResult{}, err
+	}
+
+	return StartFetchJobResult{
+		SourceID: sourceID,
+		JobID:    jobID,
+	}, nil
+}
+
+type FinishFetchJobInput struct {
+	Status          string  `json:"status"`
+	FetchedCount    int     `json:"fetched_count"`
+	InsertedCount   int     `json:"inserted_count"`
+	DuplicatedCount int     `json:"duplicated_count"`
+	ErrorMessage    *string `json:"error_message"`
+}
+
+func (s *ArticleService) FinishFetchJob(ctx context.Context, jobID int64, input FinishFetchJobInput) error {
+	if jobID < 1 {
+		return newServiceError(ErrValidation, "job_id is required")
+	}
+	if input.Status != "success" && input.Status != "failed" {
+		return newServiceError(ErrValidation, "status must be success or failed")
+	}
+	if input.FetchedCount < 0 || input.InsertedCount < 0 || input.DuplicatedCount < 0 {
+		return newServiceError(ErrValidation, "counts must be greater than or equal to 0")
+	}
+
+	job, err := s.jobRepo.GetByID(ctx, jobID)
+	if err != nil {
+		return err
+	}
+	if job == nil {
+		return newServiceError(ErrNotFound, "fetch job not found")
+	}
+	if job.Status != "running" {
+		return newServiceError(ErrConflict, "fetch job is already finished")
+	}
+
+	errorMessage := normalizeOptionalString(input.ErrorMessage)
+	if input.Status == "failed" && errorMessage == nil {
+		return newServiceError(ErrValidation, "error_message is required when status is failed")
+	}
+	if input.Status == "success" {
+		errorMessage = nil
+	}
+
+	if err := s.jobRepo.Finish(ctx, jobID, input.Status, input.FetchedCount, input.InsertedCount, input.DuplicatedCount, errorMessage); err != nil {
+		return err
+	}
+	if err := s.sourceRepo.UpdateFetchStatus(ctx, job.SourceID, input.Status, errorMessage); err != nil {
+		return err
+	}
+	return nil
 }
 
 func sanitizeSourceInput(input SourceInput) (domain.Source, error) {
@@ -277,4 +386,15 @@ func mapSourceError(err error) error {
 
 func newServiceError(kind error, message string) error {
 	return &serviceError{kind: kind, message: message}
+}
+
+func normalizeOptionalString(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
 }

--- a/services/article-service/internal/service/article_service_test.go
+++ b/services/article-service/internal/service/article_service_test.go
@@ -1,0 +1,251 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"tech-feed-hub/article-service/internal/domain"
+)
+
+type stubArticleRepo struct {
+	bulkUpsertFunc func(ctx context.Context, sourceID int64, articles []domain.Article) (int, int, error)
+}
+
+func (r *stubArticleRepo) List(context.Context, domain.ListArticlesParams) (domain.ListArticlesResult, error) {
+	return domain.ListArticlesResult{}, nil
+}
+
+func (r *stubArticleRepo) GetByID(context.Context, int64) (*domain.Article, error) {
+	return nil, nil
+}
+
+func (r *stubArticleRepo) BulkUpsert(ctx context.Context, sourceID int64, articles []domain.Article) (int, int, error) {
+	return r.bulkUpsertFunc(ctx, sourceID, articles)
+}
+
+type stubSourceRepo struct {
+	ensureSourceFunc      func(ctx context.Context, source domain.Source) (int64, error)
+	updateFetchStatusFunc func(ctx context.Context, id int64, status string, errMsg *string) error
+}
+
+func (r *stubSourceRepo) List(context.Context) ([]domain.Source, error) {
+	return nil, nil
+}
+
+func (r *stubSourceRepo) GetByID(context.Context, int64) (*domain.Source, error) {
+	return nil, nil
+}
+
+func (r *stubSourceRepo) Create(context.Context, domain.Source) (*domain.Source, error) {
+	return nil, nil
+}
+
+func (r *stubSourceRepo) Update(context.Context, domain.Source) (*domain.Source, error) {
+	return nil, nil
+}
+
+func (r *stubSourceRepo) Delete(context.Context, int64) (bool, error) {
+	return false, nil
+}
+
+func (r *stubSourceRepo) EnsureSource(ctx context.Context, source domain.Source) (int64, error) {
+	return r.ensureSourceFunc(ctx, source)
+}
+
+func (r *stubSourceRepo) UpdateFetchStatus(ctx context.Context, id int64, status string, errMsg *string) error {
+	return r.updateFetchStatusFunc(ctx, id, status, errMsg)
+}
+
+type stubJobRepo struct {
+	getByIDFunc func(ctx context.Context, id int64) (*domain.FetchJob, error)
+	listFunc    func(ctx context.Context, params domain.ListFetchJobsParams) (domain.ListFetchJobsResult, error)
+	createFunc  func(ctx context.Context, sourceID int64) (int64, error)
+	finishFunc  func(ctx context.Context, jobID int64, status string, fetchedCount int, insertedCount int, duplicatedCount int, errMsg *string) error
+}
+
+func (r *stubJobRepo) Create(ctx context.Context, sourceID int64) (int64, error) {
+	return r.createFunc(ctx, sourceID)
+}
+
+func (r *stubJobRepo) GetByID(ctx context.Context, id int64) (*domain.FetchJob, error) {
+	return r.getByIDFunc(ctx, id)
+}
+
+func (r *stubJobRepo) List(ctx context.Context, params domain.ListFetchJobsParams) (domain.ListFetchJobsResult, error) {
+	return r.listFunc(ctx, params)
+}
+
+func (r *stubJobRepo) Finish(ctx context.Context, jobID int64, status string, fetchedCount int, insertedCount int, duplicatedCount int, errMsg *string) error {
+	return r.finishFunc(ctx, jobID, status, fetchedCount, insertedCount, duplicatedCount, errMsg)
+}
+
+func TestStartFetchJobEnsuresSourceAndCreatesJob(t *testing.T) {
+	t.Parallel()
+
+	service := &ArticleService{
+		articleRepo: &stubArticleRepo{},
+		sourceRepo: &stubSourceRepo{
+			ensureSourceFunc: func(_ context.Context, source domain.Source) (int64, error) {
+				if source.Name != "Kubernetes" {
+					t.Fatalf("unexpected source: %+v", source)
+				}
+				return 12, nil
+			},
+			updateFetchStatusFunc: func(context.Context, int64, string, *string) error { return nil },
+		},
+		jobRepo: &stubJobRepo{
+			createFunc: func(_ context.Context, sourceID int64) (int64, error) {
+				if sourceID != 12 {
+					t.Fatalf("unexpected source id: %d", sourceID)
+				}
+				return 34, nil
+			},
+			getByIDFunc: func(context.Context, int64) (*domain.FetchJob, error) { return nil, nil },
+			listFunc: func(context.Context, domain.ListFetchJobsParams) (domain.ListFetchJobsResult, error) {
+				return domain.ListFetchJobsResult{}, nil
+			},
+			finishFunc: func(context.Context, int64, string, int, int, int, *string) error { return nil },
+		},
+	}
+
+	result, err := service.StartFetchJob(context.Background(), StartFetchJobInput{
+		Source: IngestSourceInput{
+			Name:            "Kubernetes",
+			Type:            "rss",
+			FetchURL:        "https://example.com/feed.xml",
+			FetchMethod:     "rss",
+			IntervalMinutes: 60,
+			DefaultCategory: "k8s",
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartFetchJob returned error: %v", err)
+	}
+	if result.SourceID != 12 || result.JobID != 34 {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func TestFinishFetchJobUpdatesJobAndSourceStatus(t *testing.T) {
+	t.Parallel()
+
+	var updatedStatus string
+	var updatedMessage *string
+
+	service := &ArticleService{
+		articleRepo: &stubArticleRepo{},
+		sourceRepo: &stubSourceRepo{
+			ensureSourceFunc: func(context.Context, domain.Source) (int64, error) { return 0, nil },
+			updateFetchStatusFunc: func(_ context.Context, id int64, status string, errMsg *string) error {
+				if id != 9 {
+					t.Fatalf("unexpected source id: %d", id)
+				}
+				updatedStatus = status
+				updatedMessage = errMsg
+				return nil
+			},
+		},
+		jobRepo: &stubJobRepo{
+			createFunc: func(context.Context, int64) (int64, error) { return 0, nil },
+			getByIDFunc: func(_ context.Context, id int64) (*domain.FetchJob, error) {
+				return &domain.FetchJob{ID: id, SourceID: 9, Status: "running"}, nil
+			},
+			listFunc: func(context.Context, domain.ListFetchJobsParams) (domain.ListFetchJobsResult, error) {
+				return domain.ListFetchJobsResult{}, nil
+			},
+			finishFunc: func(_ context.Context, jobID int64, status string, fetchedCount int, insertedCount int, duplicatedCount int, errMsg *string) error {
+				if jobID != 21 || status != "failed" || fetchedCount != 5 || insertedCount != 2 || duplicatedCount != 3 {
+					t.Fatalf("unexpected finish args: job=%d status=%s counts=%d/%d/%d", jobID, status, fetchedCount, insertedCount, duplicatedCount)
+				}
+				if errMsg == nil || *errMsg != "network error" {
+					t.Fatalf("unexpected error message: %v", errMsg)
+				}
+				return nil
+			},
+		},
+	}
+
+	err := service.FinishFetchJob(context.Background(), 21, FinishFetchJobInput{
+		Status:          "failed",
+		FetchedCount:    5,
+		InsertedCount:   2,
+		DuplicatedCount: 3,
+		ErrorMessage:    testStringPtr("network error"),
+	})
+	if err != nil {
+		t.Fatalf("FinishFetchJob returned error: %v", err)
+	}
+	if updatedStatus != "failed" || updatedMessage == nil || *updatedMessage != "network error" {
+		t.Fatalf("unexpected source update: status=%s err=%v", updatedStatus, updatedMessage)
+	}
+}
+
+func testStringPtr(value string) *string {
+	return &value
+}
+
+func TestIngestRejectsFinishedJob(t *testing.T) {
+	t.Parallel()
+
+	service := &ArticleService{
+		articleRepo: &stubArticleRepo{
+			bulkUpsertFunc: func(context.Context, int64, []domain.Article) (int, int, error) {
+				t.Fatal("BulkUpsert should not be called")
+				return 0, 0, nil
+			},
+		},
+		sourceRepo: &stubSourceRepo{
+			ensureSourceFunc:      func(context.Context, domain.Source) (int64, error) { return 0, nil },
+			updateFetchStatusFunc: func(context.Context, int64, string, *string) error { return nil },
+		},
+		jobRepo: &stubJobRepo{
+			createFunc: func(context.Context, int64) (int64, error) { return 0, nil },
+			getByIDFunc: func(context.Context, int64) (*domain.FetchJob, error) {
+				finishedAt := time.Now().UTC()
+				return &domain.FetchJob{ID: 10, SourceID: 3, Status: "success", FinishedAt: &finishedAt}, nil
+			},
+			listFunc: func(context.Context, domain.ListFetchJobsParams) (domain.ListFetchJobsResult, error) {
+				return domain.ListFetchJobsResult{}, nil
+			},
+			finishFunc: func(context.Context, int64, string, int, int, int, *string) error { return nil },
+		},
+	}
+
+	_, err := service.Ingest(context.Background(), IngestRequest{
+		JobID:    10,
+		SourceID: 3,
+		Source: IngestSourceInput{
+			DefaultCategory: "k8s",
+		},
+	})
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected ErrConflict, got: %v", err)
+	}
+}
+
+func TestListFetchJobsRequiresSourceID(t *testing.T) {
+	t.Parallel()
+
+	service := &ArticleService{
+		articleRepo: &stubArticleRepo{},
+		sourceRepo: &stubSourceRepo{
+			ensureSourceFunc:      func(context.Context, domain.Source) (int64, error) { return 0, nil },
+			updateFetchStatusFunc: func(context.Context, int64, string, *string) error { return nil },
+		},
+		jobRepo: &stubJobRepo{
+			createFunc:  func(context.Context, int64) (int64, error) { return 0, nil },
+			getByIDFunc: func(context.Context, int64) (*domain.FetchJob, error) { return nil, nil },
+			listFunc: func(context.Context, domain.ListFetchJobsParams) (domain.ListFetchJobsResult, error) {
+				return domain.ListFetchJobsResult{}, nil
+			},
+			finishFunc: func(context.Context, int64, string, int, int, int, *string) error { return nil },
+		},
+	}
+
+	_, err := service.ListFetchJobs(context.Background(), domain.ListFetchJobsParams{})
+	if !errors.Is(err, ErrValidation) {
+		t.Fatalf("expected ErrValidation, got: %v", err)
+	}
+}

--- a/services/collector-service/internal/collector/service.go
+++ b/services/collector-service/internal/collector/service.go
@@ -35,6 +35,8 @@ type rssItem struct {
 }
 
 type IngestPayload struct {
+	JobID    int64           `json:"job_id"`
+	SourceID int64           `json:"source_id"`
 	Source   IngestSource    `json:"source"`
 	Articles []IngestArticle `json:"articles"`
 }
@@ -61,9 +63,13 @@ type IngestArticle struct {
 
 type RunResult struct {
 	SourceName      string `json:"source_name"`
+	SourceID        int64  `json:"source_id"`
+	JobID           int64  `json:"job_id"`
+	Status          string `json:"status"`
 	FetchedCount    int    `json:"fetched_count"`
 	InsertedCount   int    `json:"inserted_count"`
 	DuplicatedCount int    `json:"duplicated_count"`
+	ErrorMessage    string `json:"error_message,omitempty"`
 }
 
 type Service struct {
@@ -93,12 +99,26 @@ func (s *Service) Run(ctx context.Context) ([]RunResult, error) {
 }
 
 func (s *Service) collectSource(ctx context.Context, source SourceConfig) (RunResult, error) {
-	items, err := s.fetchRSS(ctx, source)
+	started, err := s.startFetchJob(ctx, source)
 	if err != nil {
 		return RunResult{}, err
 	}
 
+	items, err := s.fetchRSS(ctx, source)
+	if err != nil {
+		finishErr := s.finishFetchJob(ctx, started.JobID, finishFetchJobPayload{
+			Status:       "failed",
+			ErrorMessage: stringPtr(err.Error()),
+		})
+		if finishErr != nil {
+			return RunResult{}, finishErr
+		}
+		return RunResult{}, err
+	}
+
 	payload := IngestPayload{
+		JobID:    started.JobID,
+		SourceID: started.SourceID,
 		Source: IngestSource{
 			Name:            source.Name,
 			Type:            source.Type,
@@ -112,24 +132,53 @@ func (s *Service) collectSource(ctx context.Context, source SourceConfig) (RunRe
 
 	body, err := json.Marshal(payload)
 	if err != nil {
+		finishErr := s.finishFetchJob(ctx, started.JobID, finishFetchJobPayload{
+			Status:       "failed",
+			ErrorMessage: stringPtr(fmt.Sprintf("marshal ingest payload: %v", err)),
+		})
+		if finishErr != nil {
+			return RunResult{}, finishErr
+		}
 		return RunResult{}, fmt.Errorf("marshal ingest payload: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.articleServiceURL+"/internal/ingest", bytes.NewReader(body))
 	if err != nil {
+		finishErr := s.finishFetchJob(ctx, started.JobID, finishFetchJobPayload{
+			Status:       "failed",
+			ErrorMessage: stringPtr(fmt.Sprintf("create ingest request: %v", err)),
+		})
+		if finishErr != nil {
+			return RunResult{}, finishErr
+		}
 		return RunResult{}, fmt.Errorf("create ingest request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := s.client.Do(req)
 	if err != nil {
+		finishErr := s.finishFetchJob(ctx, started.JobID, finishFetchJobPayload{
+			Status:       "failed",
+			ErrorMessage: stringPtr(fmt.Sprintf("send ingest request: %v", err)),
+		})
+		if finishErr != nil {
+			return RunResult{}, finishErr
+		}
 		return RunResult{}, fmt.Errorf("send ingest request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 300 {
 		raw, _ := io.ReadAll(resp.Body)
-		return RunResult{}, fmt.Errorf("ingest failed: status=%d body=%s", resp.StatusCode, string(raw))
+		message := fmt.Sprintf("ingest failed: status=%d body=%s", resp.StatusCode, string(raw))
+		finishErr := s.finishFetchJob(ctx, started.JobID, finishFetchJobPayload{
+			Status:       "failed",
+			ErrorMessage: stringPtr(message),
+		})
+		if finishErr != nil {
+			return RunResult{}, finishErr
+		}
+		return RunResult{}, fmt.Errorf("%s", message)
 	}
 
 	var ingestResult struct {
@@ -137,15 +186,117 @@ func (s *Service) collectSource(ctx context.Context, source SourceConfig) (RunRe
 		DuplicatedCount int `json:"duplicated_count"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&ingestResult); err != nil {
+		finishErr := s.finishFetchJob(ctx, started.JobID, finishFetchJobPayload{
+			Status:       "failed",
+			ErrorMessage: stringPtr(fmt.Sprintf("decode ingest response: %v", err)),
+		})
+		if finishErr != nil {
+			return RunResult{}, finishErr
+		}
 		return RunResult{}, fmt.Errorf("decode ingest response: %w", err)
+	}
+
+	if err := s.finishFetchJob(ctx, started.JobID, finishFetchJobPayload{
+		Status:          "success",
+		FetchedCount:    len(items),
+		InsertedCount:   ingestResult.InsertedCount,
+		DuplicatedCount: ingestResult.DuplicatedCount,
+	}); err != nil {
+		return RunResult{}, err
 	}
 
 	return RunResult{
 		SourceName:      source.Name,
+		SourceID:        started.SourceID,
+		JobID:           started.JobID,
+		Status:          "success",
 		FetchedCount:    len(items),
 		InsertedCount:   ingestResult.InsertedCount,
 		DuplicatedCount: ingestResult.DuplicatedCount,
 	}, nil
+}
+
+type startFetchJobPayload struct {
+	Source IngestSource `json:"source"`
+}
+
+type startFetchJobResult struct {
+	SourceID int64 `json:"source_id"`
+	JobID    int64 `json:"job_id"`
+}
+
+func (s *Service) startFetchJob(ctx context.Context, source SourceConfig) (startFetchJobResult, error) {
+	payload := startFetchJobPayload{
+		Source: IngestSource{
+			Name:            source.Name,
+			Type:            source.Type,
+			FetchURL:        source.URL,
+			FetchMethod:     "rss",
+			IntervalMinutes: 60,
+			DefaultCategory: source.DefaultCategory,
+		},
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return startFetchJobResult{}, fmt.Errorf("marshal fetch job start payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.articleServiceURL+"/internal/fetch-jobs/start", bytes.NewReader(body))
+	if err != nil {
+		return startFetchJobResult{}, fmt.Errorf("create fetch job start request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return startFetchJobResult{}, fmt.Errorf("send fetch job start request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		raw, _ := io.ReadAll(resp.Body)
+		return startFetchJobResult{}, fmt.Errorf("fetch job start failed: status=%d body=%s", resp.StatusCode, string(raw))
+	}
+
+	var result startFetchJobResult
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return startFetchJobResult{}, fmt.Errorf("decode fetch job start response: %w", err)
+	}
+	return result, nil
+}
+
+type finishFetchJobPayload struct {
+	Status          string  `json:"status"`
+	FetchedCount    int     `json:"fetched_count"`
+	InsertedCount   int     `json:"inserted_count"`
+	DuplicatedCount int     `json:"duplicated_count"`
+	ErrorMessage    *string `json:"error_message"`
+}
+
+func (s *Service) finishFetchJob(ctx context.Context, jobID int64, payload finishFetchJobPayload) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal fetch job finish payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/internal/fetch-jobs/%d/finish", s.articleServiceURL, jobID), bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create fetch job finish request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send fetch job finish request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		raw, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("fetch job finish failed: status=%d body=%s", resp.StatusCode, string(raw))
+	}
+	return nil
 }
 
 func (s *Service) fetchRSS(ctx context.Context, source SourceConfig) ([]IngestArticle, error) {
@@ -222,4 +373,8 @@ func stripHTML(value string) string {
 	cleaned := replacer.Replace(value)
 	cleaned = strings.NewReplacer("<", " ", ">", " ").Replace(cleaned)
 	return strings.Join(strings.Fields(cleaned), " ")
+}
+
+func stringPtr(value string) *string {
+	return &value
 }

--- a/services/collector-service/internal/collector/service_http_test.go
+++ b/services/collector-service/internal/collector/service_http_test.go
@@ -1,0 +1,109 @@
+package collector
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRunCreatesAndFinishesFetchJobOnSuccess(t *testing.T) {
+	t.Parallel()
+
+	var startCalled bool
+	var finishPayload finishFetchJobPayload
+	var ingestPayload IngestPayload
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/rss":
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = io.WriteString(w, `<?xml version="1.0"?><rss><channel><item><title>Hello</title><link>https://example.com/1</link><description>desc</description><pubDate>Mon, 02 Jan 2006 15:04:05 +0900</pubDate></item></channel></rss>`)
+		case "/internal/fetch-jobs/start":
+			startCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"source_id":7,"job_id":11}`)
+		case "/internal/ingest":
+			if err := json.NewDecoder(r.Body).Decode(&ingestPayload); err != nil {
+				t.Fatalf("decode ingest payload: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"source_id":7,"job_id":11,"fetched_count":1,"inserted_count":1,"duplicated_count":0}`)
+		case "/internal/fetch-jobs/11/finish":
+			if err := json.NewDecoder(r.Body).Decode(&finishPayload); err != nil {
+				t.Fatalf("decode finish payload: %v", err)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	service := NewService(server.URL, []SourceConfig{{
+		Name:            "Example",
+		Type:            "rss",
+		URL:             server.URL + "/rss",
+		DefaultCategory: "cloud",
+	}})
+
+	results, err := service.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if !startCalled {
+		t.Fatal("expected start to be called")
+	}
+	if ingestPayload.JobID != 11 || ingestPayload.SourceID != 7 {
+		t.Fatalf("unexpected ingest payload ids: %+v", ingestPayload)
+	}
+	if finishPayload.Status != "success" || finishPayload.FetchedCount != 1 || finishPayload.InsertedCount != 1 || finishPayload.DuplicatedCount != 0 || finishPayload.ErrorMessage != nil {
+		t.Fatalf("unexpected finish payload: %+v", finishPayload)
+	}
+	if len(results) != 1 || results[0].Status != "success" || results[0].JobID != 11 || results[0].SourceID != 7 {
+		t.Fatalf("unexpected results: %+v", results)
+	}
+}
+
+func TestRunFinishesFetchJobOnRSSFailure(t *testing.T) {
+	t.Parallel()
+
+	var finishPayload finishFetchJobPayload
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/rss":
+			http.Error(w, "boom", http.StatusBadGateway)
+		case r.URL.Path == "/internal/fetch-jobs/start":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"source_id":7,"job_id":11}`)
+		case r.URL.Path == "/internal/fetch-jobs/11/finish":
+			if err := json.NewDecoder(r.Body).Decode(&finishPayload); err != nil {
+				t.Fatalf("decode finish payload: %v", err)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	service := NewService(server.URL, []SourceConfig{{
+		Name:            "Example",
+		Type:            "rss",
+		URL:             server.URL + "/rss",
+		DefaultCategory: "cloud",
+	}})
+
+	_, err := service.Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "fetch rss status=502") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if finishPayload.Status != "failed" || finishPayload.ErrorMessage == nil || !strings.Contains(*finishPayload.ErrorMessage, "fetch rss status=502") {
+		t.Fatalf("unexpected finish payload: %+v", finishPayload)
+	}
+}


### PR DESCRIPTION
## 概要

- 取得ジョブ履歴の一覧 API と collector のジョブ開始/終了 API を追加
- source 詳細画面で最終取得結果とジョブ履歴を確認できる UI を追加
- OpenAPI、runbook、current status などの関連ドキュメントを更新

## 背景 / 目的

- Issue #2 の対応として、collector の成功/失敗をログに依存せずアプリ上で確認できるようにする
- source ごとの直近状態と過去の取得履歴を追えるようにし、後続の通知やリトライ機能と矛盾しない土台を作る

## 変更内容

- `article-service` に `GET /api/v1/fetch-jobs` を追加
- `article-service` に internal の fetch job start/finish API を追加し、`/internal/ingest` は既存 job に紐づく ingest のみに変更
- `collector-service` を `start -> fetch -> ingest -> finish` の流れへ変更し、失敗時も job を `failed` で確実に記録
- `api-gateway` で `/api/v1/fetch-jobs` を公開
- `frontend` に source 詳細ページを追加し、status フィルタとページネーション付きのジョブ履歴を表示
- OpenAPI、DB ガイドライン、runbook、current status、known issues を更新

## 影響範囲

- [x] frontend
- [x] api-gateway
- [x] collector-service
- [x] article-service
- [ ] notification-service
- [ ] infra
- [x] docs

## 検証

- [x] `go test ./...`
- [x] `npm run build`
- [x] `docker compose config -q`
- [x] その他: `make verify`

## API / DB / Infra への影響

- [x] API を変更した
- [x] DB schema を変更した
- [ ] Compose を変更した
- [ ] Kubernetes / Helm を変更した
- [ ] 大きな影響はない

## ドキュメント

- [ ] 必要に応じて `RULES.md` を更新した
- [x] 関連する `docs/` を更新した
- [ ] ドキュメント更新は不要

## リスク / 注意点

- collector の収集対象そのものは引き続き静的設定で、source 管理画面の変更は collector の対象へ自動反映されない
- `fetch_jobs` に一覧向け index を追加しているため、初期 SQL を適用する環境との差分管理は別途注意が必要

## 補足

- Issue #2 に対応する PR ですが、自動 close は設定していません