### PR TITLE
[Phase 2] 既読 / お気に入り管理を実装

### DIFF
--- a/docs/openapi/api-gateway.yaml
+++ b/docs/openapi/api-gateway.yaml
@@ -28,6 +28,14 @@ paths:
           schema:
             type: integer
         - in: query
+          name: is_read
+          schema:
+            type: boolean
+        - in: query
+          name: is_favorite
+          schema:
+            type: boolean
+        - in: query
           name: page
           schema:
             type: integer
@@ -40,6 +48,10 @@ paths:
       responses:
         "200":
           description: Article list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListArticlesResponse"
   /api/v1/articles/{id}:
     get:
       summary: Get article detail
@@ -52,6 +64,64 @@ paths:
       responses:
         "200":
           description: Article detail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Article"
+        "404":
+          description: Article not found
+  /api/v1/articles/{id}/read-status:
+    patch:
+      summary: Update article read status
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReadStatusInput"
+      responses:
+        "200":
+          description: Updated article
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Article"
+        "400":
+          description: Validation error
+        "404":
+          description: Article not found
+  /api/v1/articles/{id}/favorite-status:
+    patch:
+      summary: Update article favorite status
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FavoriteStatusInput"
+      responses:
+        "200":
+          description: Updated article
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Article"
+        "400":
+          description: Validation error
+        "404":
+          description: Article not found
   /api/v1/sources:
     get:
       summary: List sources
@@ -186,6 +256,94 @@ paths:
           description: Validation error
 components:
   schemas:
+    Article:
+      type: object
+      properties:
+        id:
+          type: integer
+        title:
+          type: string
+        url:
+          type: string
+          format: uri
+        source_id:
+          type: integer
+        source_name:
+          type: string
+        published_at:
+          type: string
+          format: date-time
+          nullable: true
+        fetched_at:
+          type: string
+          format: date-time
+        excerpt:
+          type: string
+        category:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        is_read:
+          type: boolean
+        is_favorite:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - title
+        - url
+        - source_id
+        - source_name
+        - fetched_at
+        - excerpt
+        - category
+        - tags
+        - is_read
+        - is_favorite
+        - created_at
+        - updated_at
+    ListArticlesResponse:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/Article"
+        total:
+          type: integer
+        page:
+          type: integer
+        page_size:
+          type: integer
+        total_pages:
+          type: integer
+      required:
+        - items
+        - total
+        - page
+        - page_size
+        - total_pages
+    ReadStatusInput:
+      type: object
+      properties:
+        is_read:
+          type: boolean
+      required:
+        - is_read
+    FavoriteStatusInput:
+      type: object
+      properties:
+        is_favorite:
+          type: boolean
+      required:
+        - is_favorite
     Source:
       type: object
       properties:

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -79,6 +79,8 @@ export type ListFetchJobsResponse = {
 export async function fetchArticles(params: {
   q?: string;
   category?: string;
+  is_read?: boolean;
+  is_favorite?: boolean;
   page?: number;
 }) {
   const response = await api.get<ListArticlesResponse>("/api/v1/articles", { params });
@@ -87,6 +89,16 @@ export async function fetchArticles(params: {
 
 export async function fetchArticle(id: string) {
   const response = await api.get<Article>(`/api/v1/articles/${id}`);
+  return response.data;
+}
+
+export async function updateArticleReadStatus(id: number, isRead: boolean) {
+  const response = await api.patch<Article>(`/api/v1/articles/${id}/read-status`, { is_read: isRead });
+  return response.data;
+}
+
+export async function updateArticleFavoriteStatus(id: number, isFavorite: boolean) {
+  const response = await api.patch<Article>(`/api/v1/articles/${id}/favorite-status`, { is_favorite: isFavorite });
   return response.data;
 }
 

--- a/frontend/src/store/searchStore.ts
+++ b/frontend/src/store/searchStore.ts
@@ -3,11 +3,20 @@ import { create } from "zustand";
 type SearchState = {
   q: string;
   category: string;
-  setFilters: (next: { q: string; category: string }) => void;
+  isReadOnly: boolean;
+  isFavoriteOnly: boolean;
+  setFilters: (next: {
+    q: string;
+    category: string;
+    isReadOnly: boolean;
+    isFavoriteOnly: boolean;
+  }) => void;
 };
 
 export const useSearchStore = create<SearchState>((set) => ({
   q: "",
   category: "",
+  isReadOnly: false,
+  isFavoriteOnly: false,
   setFilters: (next) => set(next),
 }));

--- a/frontend/src/ui/ArticleDetailPage.tsx
+++ b/frontend/src/ui/ArticleDetailPage.tsx
@@ -1,12 +1,42 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useParams } from "react-router-dom";
-import { fetchArticle } from "../lib/api";
+import {
+  type Article,
+  fetchArticle,
+  type ListArticlesResponse,
+  updateArticleFavoriteStatus,
+  updateArticleReadStatus,
+} from "../lib/api";
 
 export function ArticleDetailPage() {
   const { id = "" } = useParams();
+  const queryClient = useQueryClient();
   const articleQuery = useQuery({
     queryKey: ["article", id],
     queryFn: () => fetchArticle(id),
+  });
+
+  const syncArticle = (article: Article) => {
+    queryClient.setQueryData(["article", id], article);
+    queryClient.setQueriesData({ queryKey: ["articles"] }, (current: ListArticlesResponse | undefined) => {
+      if (!current) {
+        return current;
+      }
+      return {
+        ...current,
+        items: current.items.map((item) => (item.id === article.id ? article : item)),
+      };
+    });
+  };
+
+  const readStatusMutation = useMutation({
+    mutationFn: (isRead: boolean) => updateArticleReadStatus(Number(id), isRead),
+    onSuccess: syncArticle,
+  });
+
+  const favoriteStatusMutation = useMutation({
+    mutationFn: (isFavorite: boolean) => updateArticleFavoriteStatus(Number(id), isFavorite),
+    onSuccess: syncArticle,
   });
 
   if (articleQuery.isLoading) {
@@ -27,6 +57,7 @@ export function ArticleDetailPage() {
   }
 
   const article = articleQuery.data;
+  const isUpdating = readStatusMutation.isPending || favoriteStatusMutation.isPending;
 
   return (
     <article className="space-y-6 rounded-3xl border border-white/10 bg-slate-900/70 p-8">
@@ -37,12 +68,41 @@ export function ArticleDetailPage() {
         <div className="flex flex-wrap gap-2 text-xs text-slate-400">
           <span className="rounded-full bg-amber-400/10 px-3 py-1 text-amber-200">{article.category}</span>
           <span>{article.source_name}</span>
+          <span className={article.is_read ? "rounded-full bg-slate-800 px-3 py-1 text-slate-300" : "rounded-full bg-emerald-400/10 px-3 py-1 text-emerald-200"}>
+            {article.is_read ? "既読" : "未読"}
+          </span>
+          {article.is_favorite ? (
+            <span className="rounded-full bg-amber-300/10 px-3 py-1 text-amber-100">お気に入り</span>
+          ) : null}
         </div>
         <h1 className="text-3xl font-semibold text-white">{article.title}</h1>
         <p className="text-sm text-slate-400">
           Published: {article.published_at ? formatDate(article.published_at) : "unknown"}
         </p>
       </div>
+      <div className="flex flex-wrap gap-3">
+        <button
+          type="button"
+          onClick={() => readStatusMutation.mutate(!article.is_read)}
+          disabled={isUpdating}
+          className="rounded-full border border-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:border-emerald-300/50 hover:text-emerald-200 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {article.is_read ? "未読に戻す" : "既読にする"}
+        </button>
+        <button
+          type="button"
+          onClick={() => favoriteStatusMutation.mutate(!article.is_favorite)}
+          disabled={isUpdating}
+          className="rounded-full border border-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:border-amber-300/50 hover:text-amber-200 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {article.is_favorite ? "お気に入り解除" : "お気に入りに追加"}
+        </button>
+      </div>
+      {readStatusMutation.isError || favoriteStatusMutation.isError ? (
+        <div className="rounded-2xl border border-rose-400/30 bg-rose-950/40 p-4 text-sm text-rose-200">
+          状態の更新に失敗しました。
+        </div>
+      ) : null}
       <p className="text-base leading-8 text-slate-200">{article.excerpt || "概要は未取得です。"}</p>
       <a
         href={article.url}

--- a/frontend/src/ui/ArticleListPage.tsx
+++ b/frontend/src/ui/ArticleListPage.tsx
@@ -9,20 +9,28 @@ import { useSearchStore } from "../store/searchStore";
 const schema = z.object({
   q: z.string().max(100).default(""),
   category: z.string().max(50).default(""),
+  isReadOnly: z.boolean().default(false),
+  isFavoriteOnly: z.boolean().default(false),
 });
 
 type FormValues = z.infer<typeof schema>;
 
 export function ArticleListPage() {
-  const { q, category, setFilters } = useSearchStore();
+  const { q, category, isReadOnly, isFavoriteOnly, setFilters } = useSearchStore();
   const form = useForm<FormValues>({
     resolver: zodResolver(schema),
-    defaultValues: { q, category },
+    defaultValues: { q, category, isReadOnly, isFavoriteOnly },
   });
 
   const articlesQuery = useQuery({
-    queryKey: ["articles", q, category],
-    queryFn: () => fetchArticles({ q, category }),
+    queryKey: ["articles", q, category, isReadOnly, isFavoriteOnly],
+    queryFn: () =>
+      fetchArticles({
+        q,
+        category,
+        is_read: isReadOnly ? false : undefined,
+        is_favorite: isFavoriteOnly ? true : undefined,
+      }),
   });
 
   const onSubmit = form.handleSubmit((values) => {
@@ -40,7 +48,7 @@ export function ArticleListPage() {
           </p>
         </div>
 
-        <form onSubmit={onSubmit} className="grid gap-4 md:grid-cols-[2fr,1fr,auto]">
+        <form onSubmit={onSubmit} className="grid gap-4 md:grid-cols-2 xl:grid-cols-[2fr,1fr,auto,auto,auto]">
           <input
             {...form.register("q")}
             placeholder="タイトル・概要で検索"
@@ -57,6 +65,14 @@ export function ArticleListPage() {
           >
             Search
           </button>
+          <label className="flex items-center gap-3 rounded-2xl border border-white/10 bg-slate-950/70 px-4 py-3 text-sm text-slate-200">
+            <input type="checkbox" {...form.register("isReadOnly")} className="size-4 rounded border-white/20" />
+            未読のみ
+          </label>
+          <label className="flex items-center gap-3 rounded-2xl border border-white/10 bg-slate-950/70 px-4 py-3 text-sm text-slate-200">
+            <input type="checkbox" {...form.register("isFavoriteOnly")} className="size-4 rounded border-white/20" />
+            お気に入りのみ
+          </label>
         </form>
       </section>
 
@@ -84,6 +100,18 @@ export function ArticleListPage() {
                 <span className="rounded-full bg-cyan-400/10 px-3 py-1 text-cyan-200">{article.category}</span>
                 <span>{article.source_name}</span>
                 <span>{formatDate(article.published_at ?? article.fetched_at)}</span>
+                <span
+                  className={
+                    article.is_read
+                      ? "rounded-full bg-slate-800 px-3 py-1 text-slate-300"
+                      : "rounded-full bg-emerald-400/10 px-3 py-1 text-emerald-200"
+                  }
+                >
+                  {article.is_read ? "既読" : "未読"}
+                </span>
+                {article.is_favorite ? (
+                  <span className="rounded-full bg-amber-400/10 px-3 py-1 text-amber-200">お気に入り</span>
+                ) : null}
               </div>
               <h2 className="mb-2 text-xl font-medium text-white group-hover:text-cyan-200">{article.title}</h2>
               <p className="line-clamp-3 text-sm leading-6 text-slate-300">{article.excerpt || "概要は未取得です。"}</p>

--- a/services/api-gateway/internal/httpapi/routes.go
+++ b/services/api-gateway/internal/httpapi/routes.go
@@ -25,6 +25,14 @@ func RegisterRoutes(router *gin.Engine, articleServiceURL string) {
 			targetURL := articleServiceURL + "/api/v1/articles/" + c.Param("id")
 			proxyRequest(c, client, targetURL)
 		})
+		v1.PATCH("/articles/:id/read-status", func(c *gin.Context) {
+			targetURL := articleServiceURL + "/api/v1/articles/" + c.Param("id") + "/read-status"
+			proxyRequest(c, client, targetURL)
+		})
+		v1.PATCH("/articles/:id/favorite-status", func(c *gin.Context) {
+			targetURL := articleServiceURL + "/api/v1/articles/" + c.Param("id") + "/favorite-status"
+			proxyRequest(c, client, targetURL)
+		})
 		v1.GET("/sources", func(c *gin.Context) {
 			targetURL := articleServiceURL + "/api/v1/sources"
 			proxyRequest(c, client, targetURL)

--- a/services/api-gateway/internal/httpapi/routes_test.go
+++ b/services/api-gateway/internal/httpapi/routes_test.go
@@ -28,6 +28,12 @@ func TestProxyRequestForwardsQueryAndBody(t *testing.T) {
 			if got := req.URL.Query().Get("q"); got != "kubernetes" {
 				t.Fatalf("unexpected query: %s", got)
 			}
+			if got := req.URL.Query().Get("is_read"); got != "false" {
+				t.Fatalf("unexpected is_read: %s", got)
+			}
+			if got := req.URL.Query().Get("is_favorite"); got != "true" {
+				t.Fatalf("unexpected is_favorite: %s", got)
+			}
 
 			return &http.Response{
 				StatusCode: http.StatusOK,
@@ -39,7 +45,7 @@ func TestProxyRequestForwardsQueryAndBody(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
-	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/articles?q=kubernetes", nil)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/articles?q=kubernetes&is_read=false&is_favorite=true", nil)
 
 	proxyRequest(c, client, "http://article-service/api/v1/articles")
 
@@ -84,7 +90,7 @@ func TestProxyRequestForwardsMethodHeadersAndBody(t *testing.T) {
 			if req.Method != http.MethodPatch {
 				t.Fatalf("unexpected method: %s", req.Method)
 			}
-			if req.URL.Path != "/api/v1/sources/12" {
+			if req.URL.Path != "/api/v1/articles/12/favorite-status" {
 				t.Fatalf("unexpected path: %s", req.URL.Path)
 			}
 			if got := req.Header.Get("Content-Type"); got != "application/json" {
@@ -95,7 +101,7 @@ func TestProxyRequestForwardsMethodHeadersAndBody(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read body: %v", err)
 			}
-			if string(body) != `{"is_enabled":false}` {
+			if string(body) != `{"is_favorite":true}` {
 				t.Fatalf("unexpected body: %s", string(body))
 			}
 
@@ -109,10 +115,10 @@ func TestProxyRequestForwardsMethodHeadersAndBody(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
-	c.Request = httptest.NewRequest(http.MethodPatch, "/api/v1/sources/12", strings.NewReader(`{"is_enabled":false}`))
+	c.Request = httptest.NewRequest(http.MethodPatch, "/api/v1/articles/12/favorite-status", strings.NewReader(`{"is_favorite":true}`))
 	c.Request.Header.Set("Content-Type", "application/json")
 
-	proxyRequest(c, client, "http://article-service/api/v1/sources/12")
+	proxyRequest(c, client, "http://article-service/api/v1/articles/12/favorite-status")
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("unexpected status code: got=%d want=%d", rec.Code, http.StatusOK)

--- a/services/article-service/internal/domain/models.go
+++ b/services/article-service/internal/domain/models.go
@@ -64,13 +64,15 @@ type ListFetchJobsResult struct {
 }
 
 type ListArticlesParams struct {
-	Query    string
-	Category string
-	SourceID int64
-	Page     int
-	PageSize int
-	Sort     string
-	Order    string
+	Query      string
+	Category   string
+	SourceID   int64
+	IsRead     *bool
+	IsFavorite *bool
+	Page       int
+	PageSize   int
+	Sort       string
+	Order      string
 }
 
 type ListArticlesResult struct {

--- a/services/article-service/internal/httpapi/router.go
+++ b/services/article-service/internal/httpapi/router.go
@@ -29,15 +29,25 @@ func NewRouter(db *sql.DB, articleService *service.ArticleService) *gin.Engine {
 			sourceID, _ := strconv.ParseInt(c.Query("source_id"), 10, 64)
 			page, _ := strconv.Atoi(defaultString(c.Query("page"), "1"))
 			pageSize, _ := strconv.Atoi(defaultString(c.Query("page_size"), "20"))
+			isRead, err := parseOptionalBoolQuery(c, "is_read")
+			if err != nil {
+				return
+			}
+			isFavorite, err := parseOptionalBoolQuery(c, "is_favorite")
+			if err != nil {
+				return
+			}
 
 			result, err := articleService.ListArticles(c.Request.Context(), domain.ListArticlesParams{
-				Query:    c.Query("q"),
-				Category: c.Query("category"),
-				SourceID: sourceID,
-				Page:     page,
-				PageSize: pageSize,
-				Sort:     c.Query("sort"),
-				Order:    c.Query("order"),
+				Query:      c.Query("q"),
+				Category:   c.Query("category"),
+				SourceID:   sourceID,
+				IsRead:     isRead,
+				IsFavorite: isFavorite,
+				Page:       page,
+				PageSize:   pageSize,
+				Sort:       c.Query("sort"),
+				Order:      c.Query("order"),
 			})
 			if err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -61,6 +71,48 @@ func NewRouter(db *sql.DB, articleService *service.ArticleService) *gin.Engine {
 			}
 			if article == nil {
 				c.JSON(http.StatusNotFound, gin.H{"error": "article not found"})
+				return
+			}
+
+			c.JSON(http.StatusOK, article)
+		})
+
+		v1.PATCH("/articles/:id/read-status", func(c *gin.Context) {
+			id, err := parseIDParam(c, "article id")
+			if err != nil {
+				return
+			}
+
+			var req service.UpdateReadStatusInput
+			if err := c.ShouldBindJSON(&req); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			}
+
+			article, err := articleService.UpdateReadStatus(c.Request.Context(), id, req)
+			if err != nil {
+				writeServiceError(c, err)
+				return
+			}
+
+			c.JSON(http.StatusOK, article)
+		})
+
+		v1.PATCH("/articles/:id/favorite-status", func(c *gin.Context) {
+			id, err := parseIDParam(c, "article id")
+			if err != nil {
+				return
+			}
+
+			var req service.UpdateFavoriteStatusInput
+			if err := c.ShouldBindJSON(&req); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			}
+
+			article, err := articleService.UpdateFavoriteStatus(c.Request.Context(), id, req)
+			if err != nil {
+				writeServiceError(c, err)
 				return
 			}
 
@@ -221,6 +273,20 @@ func defaultString(value string, fallback string) string {
 		return fallback
 	}
 	return value
+}
+
+func parseOptionalBoolQuery(c *gin.Context, key string) (*bool, error) {
+	raw := c.Query(key)
+	if raw == "" {
+		return nil, nil
+	}
+
+	value, err := strconv.ParseBool(raw)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid " + key})
+		return nil, err
+	}
+	return &value, nil
 }
 
 func parseIDParam(c *gin.Context, label string) (int64, error) {

--- a/services/article-service/internal/httpapi/router.go
+++ b/services/article-service/internal/httpapi/router.go
@@ -29,6 +29,7 @@ func NewRouter(db *sql.DB, articleService *service.ArticleService) *gin.Engine {
 			sourceID, _ := strconv.ParseInt(c.Query("source_id"), 10, 64)
 			page, _ := strconv.Atoi(defaultString(c.Query("page"), "1"))
 			pageSize, _ := strconv.Atoi(defaultString(c.Query("page_size"), "20"))
+			// 未指定と false 指定を区別して repository に渡し、独立フィルタの組み合わせを保つ。
 			isRead, err := parseOptionalBoolQuery(c, "is_read")
 			if err != nil {
 				return
@@ -89,6 +90,7 @@ func NewRouter(db *sql.DB, articleService *service.ArticleService) *gin.Engine {
 				return
 			}
 
+			// 状態更新の整合性判断は service に寄せ、handler は入出力変換だけに留める。
 			article, err := articleService.UpdateReadStatus(c.Request.Context(), id, req)
 			if err != nil {
 				writeServiceError(c, err)
@@ -110,6 +112,7 @@ func NewRouter(db *sql.DB, articleService *service.ArticleService) *gin.Engine {
 				return
 			}
 
+			// お気に入り更新も read-status と同じ責務分担に揃え、公開 API の扱いを単純化する。
 			article, err := articleService.UpdateFavoriteStatus(c.Request.Context(), id, req)
 			if err != nil {
 				writeServiceError(c, err)

--- a/services/article-service/internal/repository/article_repository.go
+++ b/services/article-service/internal/repository/article_repository.go
@@ -52,6 +52,14 @@ func (r *ArticleRepository) List(ctx context.Context, params domain.ListArticles
 		where = append(where, "a.source_id = ?")
 		args = append(args, params.SourceID)
 	}
+	if params.IsRead != nil {
+		where = append(where, "a.is_read = ?")
+		args = append(args, *params.IsRead)
+	}
+	if params.IsFavorite != nil {
+		where = append(where, "a.is_favorite = ?")
+		args = append(args, *params.IsFavorite)
+	}
 
 	whereClause := strings.Join(where, " AND ")
 	countQuery := fmt.Sprintf("SELECT COUNT(*) FROM articles a WHERE %s", whereClause)
@@ -119,6 +127,40 @@ func (r *ArticleRepository) GetByID(ctx context.Context, id int64) (*domain.Arti
 		return nil, err
 	}
 	return &article, nil
+}
+
+func (r *ArticleRepository) UpdateReadStatus(ctx context.Context, id int64, isRead bool) (*domain.Article, error) {
+	result, err := r.db.ExecContext(ctx, "UPDATE articles SET is_read = ? WHERE id = ?", isRead, id)
+	if err != nil {
+		return nil, fmt.Errorf("update read status: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("read rows affected: %w", err)
+	}
+	if rowsAffected == 0 {
+		return nil, nil
+	}
+
+	return r.GetByID(ctx, id)
+}
+
+func (r *ArticleRepository) UpdateFavoriteStatus(ctx context.Context, id int64, isFavorite bool) (*domain.Article, error) {
+	result, err := r.db.ExecContext(ctx, "UPDATE articles SET is_favorite = ? WHERE id = ?", isFavorite, id)
+	if err != nil {
+		return nil, fmt.Errorf("update favorite status: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("favorite rows affected: %w", err)
+	}
+	if rowsAffected == 0 {
+		return nil, nil
+	}
+
+	return r.GetByID(ctx, id)
 }
 
 func (r *ArticleRepository) BulkUpsert(ctx context.Context, sourceID int64, articles []domain.Article) (inserted int, duplicated int, err error) {

--- a/services/article-service/internal/repository/article_repository.go
+++ b/services/article-service/internal/repository/article_repository.go
@@ -52,6 +52,7 @@ func (r *ArticleRepository) List(ctx context.Context, params domain.ListArticles
 		where = append(where, "a.source_id = ?")
 		args = append(args, params.SourceID)
 	}
+	// 未読のみ・お気に入りのみを独立指定できる前提のため、bool 条件は個別に積み上げる。
 	if params.IsRead != nil {
 		where = append(where, "a.is_read = ?")
 		args = append(args, *params.IsRead)
@@ -143,6 +144,7 @@ func (r *ArticleRepository) UpdateReadStatus(ctx context.Context, id int64, isRe
 		return nil, nil
 	}
 
+	// 更新後の最新行を返して、API レスポンスと一覧再表示の型を揃える。
 	return r.GetByID(ctx, id)
 }
 
@@ -160,6 +162,7 @@ func (r *ArticleRepository) UpdateFavoriteStatus(ctx context.Context, id int64, 
 		return nil, nil
 	}
 
+	// read-status と同じ返却契約に寄せ、frontend が更新後データをそのまま再利用できるようにする。
 	return r.GetByID(ctx, id)
 }
 

--- a/services/article-service/internal/service/article_service.go
+++ b/services/article-service/internal/service/article_service.go
@@ -102,6 +102,7 @@ func (s *ArticleService) UpdateReadStatus(ctx context.Context, id int64, input U
 		return nil, newServiceError(ErrValidation, "article id is required")
 	}
 
+	// 初期は記事テーブル内の単純 state 更新で閉じ、ユーザー別の抽象化は持ち込まない。
 	article, err := s.articleRepo.UpdateReadStatus(ctx, id, input.IsRead)
 	if err != nil {
 		return nil, err
@@ -117,6 +118,7 @@ func (s *ArticleService) UpdateFavoriteStatus(ctx context.Context, id int64, inp
 		return nil, newServiceError(ErrValidation, "article id is required")
 	}
 
+	// favorite も article-service の責務内で完結させ、gateway 側に状態判断を持たせない。
 	article, err := s.articleRepo.UpdateFavoriteStatus(ctx, id, input.IsFavorite)
 	if err != nil {
 		return nil, err

--- a/services/article-service/internal/service/article_service.go
+++ b/services/article-service/internal/service/article_service.go
@@ -40,6 +40,8 @@ type ArticleService struct {
 type articleRepository interface {
 	List(ctx context.Context, params domain.ListArticlesParams) (domain.ListArticlesResult, error)
 	GetByID(ctx context.Context, id int64) (*domain.Article, error)
+	UpdateReadStatus(ctx context.Context, id int64, isRead bool) (*domain.Article, error)
+	UpdateFavoriteStatus(ctx context.Context, id int64, isFavorite bool) (*domain.Article, error)
 	BulkUpsert(ctx context.Context, sourceID int64, articles []domain.Article) (inserted int, duplicated int, err error)
 }
 
@@ -85,6 +87,44 @@ func (s *ArticleService) ListArticles(ctx context.Context, params domain.ListArt
 
 func (s *ArticleService) GetArticle(ctx context.Context, id int64) (*domain.Article, error) {
 	return s.articleRepo.GetByID(ctx, id)
+}
+
+type UpdateReadStatusInput struct {
+	IsRead bool `json:"is_read"`
+}
+
+type UpdateFavoriteStatusInput struct {
+	IsFavorite bool `json:"is_favorite"`
+}
+
+func (s *ArticleService) UpdateReadStatus(ctx context.Context, id int64, input UpdateReadStatusInput) (*domain.Article, error) {
+	if id < 1 {
+		return nil, newServiceError(ErrValidation, "article id is required")
+	}
+
+	article, err := s.articleRepo.UpdateReadStatus(ctx, id, input.IsRead)
+	if err != nil {
+		return nil, err
+	}
+	if article == nil {
+		return nil, newServiceError(ErrNotFound, "article not found")
+	}
+	return article, nil
+}
+
+func (s *ArticleService) UpdateFavoriteStatus(ctx context.Context, id int64, input UpdateFavoriteStatusInput) (*domain.Article, error) {
+	if id < 1 {
+		return nil, newServiceError(ErrValidation, "article id is required")
+	}
+
+	article, err := s.articleRepo.UpdateFavoriteStatus(ctx, id, input.IsFavorite)
+	if err != nil {
+		return nil, err
+	}
+	if article == nil {
+		return nil, newServiceError(ErrNotFound, "article not found")
+	}
+	return article, nil
 }
 
 type SourceInput struct {

--- a/services/article-service/internal/service/article_service_test.go
+++ b/services/article-service/internal/service/article_service_test.go
@@ -10,14 +10,38 @@ import (
 )
 
 type stubArticleRepo struct {
-	bulkUpsertFunc func(ctx context.Context, sourceID int64, articles []domain.Article) (int, int, error)
+	listFunc                 func(ctx context.Context, params domain.ListArticlesParams) (domain.ListArticlesResult, error)
+	getByIDFunc              func(ctx context.Context, id int64) (*domain.Article, error)
+	updateReadStatusFunc     func(ctx context.Context, id int64, isRead bool) (*domain.Article, error)
+	updateFavoriteStatusFunc func(ctx context.Context, id int64, isFavorite bool) (*domain.Article, error)
+	bulkUpsertFunc           func(ctx context.Context, sourceID int64, articles []domain.Article) (int, int, error)
 }
 
-func (r *stubArticleRepo) List(context.Context, domain.ListArticlesParams) (domain.ListArticlesResult, error) {
+func (r *stubArticleRepo) List(ctx context.Context, params domain.ListArticlesParams) (domain.ListArticlesResult, error) {
+	if r.listFunc != nil {
+		return r.listFunc(ctx, params)
+	}
 	return domain.ListArticlesResult{}, nil
 }
 
-func (r *stubArticleRepo) GetByID(context.Context, int64) (*domain.Article, error) {
+func (r *stubArticleRepo) GetByID(ctx context.Context, id int64) (*domain.Article, error) {
+	if r.getByIDFunc != nil {
+		return r.getByIDFunc(ctx, id)
+	}
+	return nil, nil
+}
+
+func (r *stubArticleRepo) UpdateReadStatus(ctx context.Context, id int64, isRead bool) (*domain.Article, error) {
+	if r.updateReadStatusFunc != nil {
+		return r.updateReadStatusFunc(ctx, id, isRead)
+	}
+	return nil, nil
+}
+
+func (r *stubArticleRepo) UpdateFavoriteStatus(ctx context.Context, id int64, isFavorite bool) (*domain.Article, error) {
+	if r.updateFavoriteStatusFunc != nil {
+		return r.updateFavoriteStatusFunc(ctx, id, isFavorite)
+	}
 	return nil, nil
 }
 
@@ -247,5 +271,110 @@ func TestListFetchJobsRequiresSourceID(t *testing.T) {
 	_, err := service.ListFetchJobs(context.Background(), domain.ListFetchJobsParams{})
 	if !errors.Is(err, ErrValidation) {
 		t.Fatalf("expected ErrValidation, got: %v", err)
+	}
+}
+
+func TestListArticlesPassesReadAndFavoriteFilters(t *testing.T) {
+	t.Parallel()
+
+	isRead := false
+	isFavorite := true
+
+	service := &ArticleService{
+		articleRepo: &stubArticleRepo{
+			listFunc: func(_ context.Context, params domain.ListArticlesParams) (domain.ListArticlesResult, error) {
+				if params.IsRead == nil || *params.IsRead != isRead {
+					t.Fatalf("unexpected is_read: %#v", params.IsRead)
+				}
+				if params.IsFavorite == nil || *params.IsFavorite != isFavorite {
+					t.Fatalf("unexpected is_favorite: %#v", params.IsFavorite)
+				}
+				return domain.ListArticlesResult{}, nil
+			},
+		},
+		sourceRepo: &stubSourceRepo{
+			ensureSourceFunc:      func(context.Context, domain.Source) (int64, error) { return 0, nil },
+			updateFetchStatusFunc: func(context.Context, int64, string, *string) error { return nil },
+		},
+		jobRepo: &stubJobRepo{
+			createFunc:  func(context.Context, int64) (int64, error) { return 0, nil },
+			getByIDFunc: func(context.Context, int64) (*domain.FetchJob, error) { return nil, nil },
+			listFunc: func(context.Context, domain.ListFetchJobsParams) (domain.ListFetchJobsResult, error) {
+				return domain.ListFetchJobsResult{}, nil
+			},
+			finishFunc: func(context.Context, int64, string, int, int, int, *string) error { return nil },
+		},
+	}
+
+	_, err := service.ListArticles(context.Background(), domain.ListArticlesParams{
+		IsRead:     &isRead,
+		IsFavorite: &isFavorite,
+	})
+	if err != nil {
+		t.Fatalf("ListArticles returned error: %v", err)
+	}
+}
+
+func TestUpdateReadStatusReturnsUpdatedArticle(t *testing.T) {
+	t.Parallel()
+
+	service := &ArticleService{
+		articleRepo: &stubArticleRepo{
+			updateReadStatusFunc: func(_ context.Context, id int64, isRead bool) (*domain.Article, error) {
+				if id != 7 || !isRead {
+					t.Fatalf("unexpected args: id=%d isRead=%t", id, isRead)
+				}
+				return &domain.Article{ID: id, IsRead: isRead}, nil
+			},
+		},
+		sourceRepo: &stubSourceRepo{
+			ensureSourceFunc:      func(context.Context, domain.Source) (int64, error) { return 0, nil },
+			updateFetchStatusFunc: func(context.Context, int64, string, *string) error { return nil },
+		},
+		jobRepo: &stubJobRepo{
+			createFunc:  func(context.Context, int64) (int64, error) { return 0, nil },
+			getByIDFunc: func(context.Context, int64) (*domain.FetchJob, error) { return nil, nil },
+			listFunc: func(context.Context, domain.ListFetchJobsParams) (domain.ListFetchJobsResult, error) {
+				return domain.ListFetchJobsResult{}, nil
+			},
+			finishFunc: func(context.Context, int64, string, int, int, int, *string) error { return nil },
+		},
+	}
+
+	article, err := service.UpdateReadStatus(context.Background(), 7, UpdateReadStatusInput{IsRead: true})
+	if err != nil {
+		t.Fatalf("UpdateReadStatus returned error: %v", err)
+	}
+	if article == nil || article.ID != 7 || !article.IsRead {
+		t.Fatalf("unexpected article: %+v", article)
+	}
+}
+
+func TestUpdateFavoriteStatusReturnsNotFoundWhenArticleMissing(t *testing.T) {
+	t.Parallel()
+
+	service := &ArticleService{
+		articleRepo: &stubArticleRepo{
+			updateFavoriteStatusFunc: func(context.Context, int64, bool) (*domain.Article, error) {
+				return nil, nil
+			},
+		},
+		sourceRepo: &stubSourceRepo{
+			ensureSourceFunc:      func(context.Context, domain.Source) (int64, error) { return 0, nil },
+			updateFetchStatusFunc: func(context.Context, int64, string, *string) error { return nil },
+		},
+		jobRepo: &stubJobRepo{
+			createFunc:  func(context.Context, int64) (int64, error) { return 0, nil },
+			getByIDFunc: func(context.Context, int64) (*domain.FetchJob, error) { return nil, nil },
+			listFunc: func(context.Context, domain.ListFetchJobsParams) (domain.ListFetchJobsResult, error) {
+				return domain.ListFetchJobsResult{}, nil
+			},
+			finishFunc: func(context.Context, int64, string, int, int, int, *string) error { return nil },
+		},
+	}
+
+	_, err := service.UpdateFavoriteStatus(context.Background(), 8, UpdateFavoriteStatusInput{IsFavorite: true})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got: %v", err)
 	}
 }


### PR DESCRIPTION
## 概要

- Issue #3 として、記事の既読 / お気に入り管理を追加しました
- 記事一覧の未読のみ / お気に入りのみフィルタと、記事詳細画面での状態切り替えに対応しました
- Closes #3

## 背景 / 目的

- 単一ユーザー前提でも、記事の確認状況と後で見返したい記事を軽量に管理できるようにするため
- Phase 2 の閲覧体験向上として、一覧絞り込みと詳細画面の状態更新を揃えるため

## 変更内容

- `article-service` に `is_read` / `is_favorite` フィルタ付きの記事一覧取得を追加
- `article-service` に `PATCH /api/v1/articles/{id}/read-status` と `PATCH /api/v1/articles/{id}/favorite-status` を追加
- `api-gateway` に上記 2 API の透過ルートを追加
- frontend の記事一覧画面に `未読のみ` / `お気に入りのみ` フィルタと状態表示を追加
- frontend の記事詳細画面に既読 / お気に入りの手動切り替えを追加
- OpenAPI を更新
- service / gateway のテストを追加

## 影響範囲

- [x] frontend
- [x] api-gateway
- [ ] collector-service
- [x] article-service
- [ ] notification-service
- [ ] infra
- [x] docs

## 検証

- [x] `go test ./...`
- [x] `npm run build`
- [x] `docker compose config -q`
- [x] その他: `make verify`

## API / DB / Infra への影響

- [x] API を変更した
- [ ] DB schema を変更した
- [ ] Compose を変更した
- [ ] Kubernetes / Helm を変更した
- [ ] 大きな影響はない

## ドキュメント

- [ ] 必要に応じて `RULES.md` を更新した
- [x] 関連する `docs/` を更新した
- [ ] ドキュメント更新は不要

## リスク / 注意点

- 既読は自動付与せず、記事詳細画面からの手動切り替えのみです
- 一覧画面では状態表示と絞り込みのみで、状態更新操作は持たせていません

## 補足

- 状態は既存の `articles.is_read` / `articles.is_favorite` をそのまま利用しており、単一ユーザー前提のまま実装しています
- 一覧と詳細の表示差分を避けるため、詳細更新後は React Query のキャッシュも同期しています
