### PR TITLE
記事検索結果のCSV出力を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,14 @@
 
 - `AGENT.md` と `README.md` の現在地を Phase 1 完了後の状態に同期
 - `docs/current-status.md` と `docs/known-issues.md` をソース管理実装後の状態に更新
+- 記事一覧 API と CSV エクスポートで `source_id`, `from`, `to` を含む共通フィルタを利用
+- `api-gateway` の CSV API 方針を `GET /api/v1/exports/articles.csv` に統一
 
 ### Added
 
+- article-service の記事 CSV エクスポート API
+- api-gateway 経由の CSV ダウンロード API
+- frontend の source / 公開日範囲フィルタと CSV ダウンロード導線
 - article-service のソース管理 CRUD API
 - api-gateway 経由のソース管理 API 公開
 - frontend のソース一覧 / 作成 / 編集 / 有効無効切り替え画面

--- a/docs/api-guidelines.md
+++ b/docs/api-guidelines.md
@@ -55,7 +55,7 @@
 - `GET /api/v1/sources`
 - `POST /api/v1/sources`
 - `PATCH /api/v1/sources/{id}`
-- `POST /api/v1/exports/articles.csv`
+- `GET /api/v1/exports/articles.csv`
 
 ## Query Parameter Rules
 

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -26,6 +26,7 @@
 - `api-gateway` 経由のソース管理 API 公開
 - `collector-service` の最小 RSS 収集フロー
 - `frontend` の記事一覧 / 詳細 / 検索画面
+- `frontend` の記事検索結果 CSV ダウンロード
 - `frontend` のソース一覧 / 作成 / 編集 / 有効無効切り替え画面
 - `frontend` の source 詳細と取得ジョブ履歴確認画面
 - MySQL 初期スキーマ
@@ -44,10 +45,10 @@
 
 ## Highest Priority Next
 
-1. 既読 / お気に入り管理
-2. CSV 出力
-3. collector-service のソース管理連携
-4. notification-service と RabbitMQ 連携
+1. collector-service のソース管理連携
+2. notification-service と RabbitMQ 連携
+3. Compose 整備、GitHub Actions、OpenAPI 保守
+4. kind / Helm / Argo CD の整備
 
 ## Open GitHub Issues
 
@@ -63,8 +64,6 @@
 
 - ソース管理 UI/API とジョブ履歴 UI/API は実装済みだが、collector-service はまだ静的設定依存
 - 認証は未実装
-- 既読 / お気に入りは未実装
-- CSV 出力は未実装
 - Notification と RabbitMQ は未実装
 - kind / Helm / Argo CD は未着手
 

--- a/docs/openapi/api-gateway.yaml
+++ b/docs/openapi/api-gateway.yaml
@@ -36,6 +36,16 @@ paths:
           schema:
             type: boolean
         - in: query
+          name: from
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: to
+          schema:
+            type: string
+            format: date-time
+        - in: query
           name: page
           schema:
             type: integer
@@ -52,6 +62,65 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ListArticlesResponse"
+        "400":
+          description: Validation error
+  /api/v1/exports/articles.csv:
+    get:
+      summary: Export filtered articles as CSV
+      parameters:
+        - in: query
+          name: q
+          schema:
+            type: string
+        - in: query
+          name: category
+          schema:
+            type: string
+        - in: query
+          name: source_id
+          schema:
+            type: integer
+        - in: query
+          name: is_read
+          schema:
+            type: boolean
+        - in: query
+          name: is_favorite
+          schema:
+            type: boolean
+        - in: query
+          name: from
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: to
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: sort
+          schema:
+            type: string
+            enum:
+              - created_at
+        - in: query
+          name: order
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
+      responses:
+        "200":
+          description: CSV export
+          content:
+            text/csv:
+              schema:
+                type: string
+                format: binary
+        "400":
+          description: Validation error
   /api/v1/articles/{id}:
     get:
       summary: Get article detail

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -76,15 +76,35 @@ export type ListFetchJobsResponse = {
   total_pages: number;
 };
 
-export async function fetchArticles(params: {
+export type ArticleQueryParams = {
   q?: string;
   category?: string;
+  source_id?: number;
   is_read?: boolean;
   is_favorite?: boolean;
+  from?: string;
+  to?: string;
+  sort?: string;
+  order?: string;
   page?: number;
-}) {
-  const response = await api.get<ListArticlesResponse>("/api/v1/articles", { params });
+};
+
+export async function fetchArticles(params: ArticleQueryParams) {
+  const response = await api.get<ListArticlesResponse>("/api/v1/articles", { params: buildArticleQueryParams(params) });
   return response.data;
+}
+
+export function buildArticleExportUrl(params: ArticleQueryParams) {
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(buildArticleQueryParams(params))) {
+    if (value === undefined) {
+      continue;
+    }
+    searchParams.set(key, String(value));
+  }
+  const query = searchParams.toString();
+  const baseURL = typeof api.defaults.baseURL === "string" ? api.defaults.baseURL.replace(/\/$/, "") : "";
+  return query ? `${baseURL}/api/v1/exports/articles.csv?${query}` : `${baseURL}/api/v1/exports/articles.csv`;
 }
 
 export async function fetchArticle(id: string) {
@@ -134,4 +154,26 @@ export async function updateSource(id: number, input: SourceInput) {
 
 export async function deleteSource(id: number) {
   await api.delete(`/api/v1/sources/${id}`);
+}
+
+function buildArticleQueryParams(params: ArticleQueryParams) {
+  return {
+    q: params.q || undefined,
+    category: params.category || undefined,
+    source_id: params.source_id,
+    is_read: params.is_read,
+    is_favorite: params.is_favorite,
+    from: normalizeDateTimeInput(params.from),
+    to: normalizeDateTimeInput(params.to),
+    sort: params.sort || undefined,
+    order: params.order || undefined,
+    page: params.page,
+  };
+}
+
+function normalizeDateTimeInput(value?: string) {
+  if (!value) {
+    return undefined;
+  }
+  return new Date(value).toISOString();
 }

--- a/frontend/src/store/searchStore.ts
+++ b/frontend/src/store/searchStore.ts
@@ -3,20 +3,29 @@ import { create } from "zustand";
 type SearchState = {
   q: string;
   category: string;
+  sourceId: string;
   isReadOnly: boolean;
   isFavoriteOnly: boolean;
+  from: string;
+  to: string;
   setFilters: (next: {
     q: string;
     category: string;
+    sourceId: string;
     isReadOnly: boolean;
     isFavoriteOnly: boolean;
+    from: string;
+    to: string;
   }) => void;
 };
 
 export const useSearchStore = create<SearchState>((set) => ({
   q: "",
   category: "",
+  sourceId: "",
   isReadOnly: false,
   isFavoriteOnly: false,
+  from: "",
+  to: "",
   setFilters: (next) => set(next),
 }));

--- a/frontend/src/ui/ArticleListPage.tsx
+++ b/frontend/src/ui/ArticleListPage.tsx
@@ -3,34 +3,53 @@ import { useQuery } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";
 import { Link } from "react-router-dom";
 import { z } from "zod";
-import { fetchArticles } from "../lib/api";
+import { buildArticleExportUrl, fetchArticles, fetchSources } from "../lib/api";
 import { useSearchStore } from "../store/searchStore";
 
 const schema = z.object({
   q: z.string().max(100).default(""),
   category: z.string().max(50).default(""),
+  sourceId: z.string().default(""),
   isReadOnly: z.boolean().default(false),
   isFavoriteOnly: z.boolean().default(false),
+  from: z.string().default(""),
+  to: z.string().default(""),
 });
 
 type FormValues = z.infer<typeof schema>;
 
 export function ArticleListPage() {
-  const { q, category, isReadOnly, isFavoriteOnly, setFilters } = useSearchStore();
+  const { q, category, sourceId, isReadOnly, isFavoriteOnly, from, to, setFilters } = useSearchStore();
   const form = useForm<FormValues>({
     resolver: zodResolver(schema),
-    defaultValues: { q, category, isReadOnly, isFavoriteOnly },
+    defaultValues: { q, category, sourceId, isReadOnly, isFavoriteOnly, from, to },
+  });
+  const sourcesQuery = useQuery({
+    queryKey: ["sources", "article-filters"],
+    queryFn: fetchSources,
   });
 
   const articlesQuery = useQuery({
-    queryKey: ["articles", q, category, isReadOnly, isFavoriteOnly],
+    queryKey: ["articles", q, category, sourceId, isReadOnly, isFavoriteOnly, from, to],
     queryFn: () =>
       fetchArticles({
         q,
         category,
+        source_id: sourceId ? Number(sourceId) : undefined,
         is_read: isReadOnly ? false : undefined,
         is_favorite: isFavoriteOnly ? true : undefined,
+        from: from || undefined,
+        to: to || undefined,
       }),
+  });
+  const exportURL = buildArticleExportUrl({
+    q,
+    category,
+    source_id: sourceId ? Number(sourceId) : undefined,
+    is_read: isReadOnly ? false : undefined,
+    is_favorite: isFavoriteOnly ? true : undefined,
+    from: from || undefined,
+    to: to || undefined,
   });
 
   const onSubmit = form.handleSubmit((values) => {
@@ -44,11 +63,11 @@ export function ArticleListPage() {
           <p className="text-sm uppercase tracking-[0.35em] text-cyan-300">Phase 1</p>
           <h1 className="text-4xl font-semibold tracking-tight text-white">技術情報の一覧・検索</h1>
           <p className="max-w-3xl text-sm leading-6 text-slate-300">
-            article-service から取得した記事を一覧表示します。後続フェーズで既読、お気に入り、CSV出力、通知を追加します。
+            article-service から取得した記事を一覧表示します。検索条件は CSV ダウンロードにもそのまま反映されます。
           </p>
         </div>
 
-        <form onSubmit={onSubmit} className="grid gap-4 md:grid-cols-2 xl:grid-cols-[2fr,1fr,auto,auto,auto]">
+        <form onSubmit={onSubmit} className="grid gap-4 md:grid-cols-2 xl:grid-cols-[2fr,1fr,1fr,1fr,auto,auto,auto]">
           <input
             {...form.register("q")}
             placeholder="タイトル・概要で検索"
@@ -57,6 +76,27 @@ export function ArticleListPage() {
           <input
             {...form.register("category")}
             placeholder="category 例: kubernetes"
+            className="rounded-2xl border border-white/10 bg-slate-950/70 px-4 py-3 text-sm text-white outline-none placeholder:text-slate-500"
+          />
+          <select
+            {...form.register("sourceId")}
+            className="rounded-2xl border border-white/10 bg-slate-950/70 px-4 py-3 text-sm text-white outline-none"
+          >
+            <option value="">all sources</option>
+            {sourcesQuery.data?.map((source) => (
+              <option key={source.id} value={String(source.id)}>
+                {source.name}
+              </option>
+            ))}
+          </select>
+          <input
+            type="datetime-local"
+            {...form.register("from")}
+            className="rounded-2xl border border-white/10 bg-slate-950/70 px-4 py-3 text-sm text-white outline-none placeholder:text-slate-500"
+          />
+          <input
+            type="datetime-local"
+            {...form.register("to")}
             className="rounded-2xl border border-white/10 bg-slate-950/70 px-4 py-3 text-sm text-white outline-none placeholder:text-slate-500"
           />
           <button
@@ -79,13 +119,26 @@ export function ArticleListPage() {
       <section className="space-y-4">
         <div className="flex items-center justify-between text-sm text-slate-400">
           <span>{articlesQuery.data?.total ?? 0} articles</span>
-          <span>検索・カテゴリフィルタ対応</span>
+          <div className="flex items-center gap-4">
+            <span>公開日範囲・source フィルタ対応</span>
+            <a
+              href={exportURL}
+              className="rounded-full border border-cyan-300/40 px-4 py-2 text-cyan-200 transition hover:border-cyan-200 hover:text-white"
+            >
+              CSV Download
+            </a>
+          </div>
         </div>
 
         {articlesQuery.isLoading ? <LoadingState /> : null}
         {articlesQuery.isError ? (
           <div className="rounded-2xl border border-rose-400/30 bg-rose-950/40 p-4 text-sm text-rose-200">
             API 取得に失敗しました。
+          </div>
+        ) : null}
+        {sourcesQuery.isError ? (
+          <div className="rounded-2xl border border-rose-400/30 bg-rose-950/40 p-4 text-sm text-rose-200">
+            source 一覧の取得に失敗しました。
           </div>
         ) : null}
 

--- a/services/api-gateway/internal/httpapi/routes.go
+++ b/services/api-gateway/internal/httpapi/routes.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -44,6 +45,11 @@ func RegisterRoutes(router *gin.Engine, articleServiceURL string) {
 		v1.GET("/fetch-jobs", func(c *gin.Context) {
 			targetURL := articleServiceURL + "/api/v1/fetch-jobs"
 			proxyRequest(c, client, targetURL)
+		})
+		v1.GET("/exports/articles.csv", func(c *gin.Context) {
+			targetURL := articleServiceURL + "/api/v1/articles/export.csv"
+			filename := "articles-" + time.Now().UTC().Format("20060102-150405") + ".csv"
+			proxyCSVDownload(c, client, targetURL, filename)
 		})
 		v1.POST("/sources", func(c *gin.Context) {
 			targetURL := articleServiceURL + "/api/v1/sources"
@@ -90,4 +96,43 @@ func proxyRequest(c *gin.Context, client *http.Client, targetURL string) {
 	}
 
 	c.Data(resp.StatusCode, resp.Header.Get("Content-Type"), body)
+}
+
+func proxyCSVDownload(c *gin.Context, client *http.Client, targetURL string, filename string) {
+	parsed, err := url.Parse(targetURL)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	parsed.RawQuery = c.Request.URL.RawQuery
+
+	req, err := http.NewRequestWithContext(c.Request.Context(), http.MethodGet, parsed.String(), nil)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	req.Header = c.Request.Header.Clone()
+
+	resp, err := client.Do(req)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
+		return
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
+		return
+	}
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		c.Data(resp.StatusCode, resp.Header.Get("Content-Type"), body)
+		return
+	}
+
+	// ダウンロード時の見え方は gateway で固定し、upstream 側は CSV 本文の生成だけに寄せる。
+	c.Header("Content-Type", "text/csv; charset=utf-8")
+	c.Header("Content-Disposition", `attachment; filename="`+filename+`"`)
+	c.Data(resp.StatusCode, "text/csv; charset=utf-8", body)
 }

--- a/services/api-gateway/internal/httpapi/routes_test.go
+++ b/services/api-gateway/internal/httpapi/routes_test.go
@@ -162,3 +162,69 @@ func TestProxyRequestForwardsFetchJobsQuery(t *testing.T) {
 		t.Fatalf("unexpected status code: got=%d want=%d", rec.Code, http.StatusOK)
 	}
 }
+
+func TestProxyCSVDownloadSetsAttachmentHeaders(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.Path != "/api/v1/articles/export.csv" {
+				t.Fatalf("unexpected path: %s", req.URL.Path)
+			}
+			if got := req.URL.Query().Get("source_id"); got != "4" {
+				t.Fatalf("unexpected source_id: %s", got)
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"text/csv; charset=utf-8"}},
+				Body:       io.NopCloser(strings.NewReader("title\nexample\n")),
+			}, nil
+		}),
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/exports/articles.csv?source_id=4", nil)
+
+	proxyCSVDownload(c, client, "http://article-service/api/v1/articles/export.csv", "articles-20260416-000000.csv")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status code: got=%d want=%d", rec.Code, http.StatusOK)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "text/csv; charset=utf-8" {
+		t.Fatalf("unexpected content type: %s", got)
+	}
+	if got := rec.Header().Get("Content-Disposition"); got != `attachment; filename="articles-20260416-000000.csv"` {
+		t.Fatalf("unexpected content disposition: %s", got)
+	}
+}
+
+func TestProxyCSVDownloadPassesThroughErrors(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"error":"invalid from"}`)),
+			}, nil
+		}),
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/exports/articles.csv?from=bad", nil)
+
+	proxyCSVDownload(c, client, "http://article-service/api/v1/articles/export.csv", "articles.csv")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("unexpected status code: got=%d want=%d", rec.Code, http.StatusBadRequest)
+	}
+	if body := rec.Body.String(); body != `{"error":"invalid from"}` {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}

--- a/services/article-service/internal/domain/models.go
+++ b/services/article-service/internal/domain/models.go
@@ -63,16 +63,27 @@ type ListFetchJobsResult struct {
 	TotalPages int        `json:"total_pages"`
 }
 
+type ArticleFilterParams struct {
+	Query         string
+	Category      string
+	SourceID      int64
+	IsRead        *bool
+	IsFavorite    *bool
+	PublishedFrom *time.Time
+	PublishedTo   *time.Time
+	Sort          string
+	Order         string
+}
+
 type ListArticlesParams struct {
-	Query      string
-	Category   string
-	SourceID   int64
-	IsRead     *bool
-	IsFavorite *bool
-	Page       int
-	PageSize   int
-	Sort       string
-	Order      string
+	ArticleFilterParams
+	Page     int
+	PageSize int
+}
+
+type ExportArticlesParams struct {
+	ArticleFilterParams
+	Limit int
 }
 
 type ListArticlesResult struct {

--- a/services/article-service/internal/httpapi/router.go
+++ b/services/article-service/internal/httpapi/router.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -26,36 +27,42 @@ func NewRouter(db *sql.DB, articleService *service.ArticleService) *gin.Engine {
 	v1 := router.Group("/api/v1")
 	{
 		v1.GET("/articles", func(c *gin.Context) {
-			sourceID, _ := strconv.ParseInt(c.Query("source_id"), 10, 64)
+			params, err := parseArticleFilterParams(c)
+			if err != nil {
+				return
+			}
 			page, _ := strconv.Atoi(defaultString(c.Query("page"), "1"))
 			pageSize, _ := strconv.Atoi(defaultString(c.Query("page_size"), "20"))
-			// 未指定と false 指定を区別して repository に渡し、独立フィルタの組み合わせを保つ。
-			isRead, err := parseOptionalBoolQuery(c, "is_read")
-			if err != nil {
-				return
-			}
-			isFavorite, err := parseOptionalBoolQuery(c, "is_favorite")
-			if err != nil {
-				return
-			}
 
 			result, err := articleService.ListArticles(c.Request.Context(), domain.ListArticlesParams{
-				Query:      c.Query("q"),
-				Category:   c.Query("category"),
-				SourceID:   sourceID,
-				IsRead:     isRead,
-				IsFavorite: isFavorite,
-				Page:       page,
-				PageSize:   pageSize,
-				Sort:       c.Query("sort"),
-				Order:      c.Query("order"),
+				ArticleFilterParams: params,
+				Page:                page,
+				PageSize:            pageSize,
 			})
 			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				writeServiceError(c, err)
 				return
 			}
 
 			c.JSON(http.StatusOK, result)
+		})
+
+		v1.GET("/articles/export.csv", func(c *gin.Context) {
+			params, err := parseArticleFilterParams(c)
+			if err != nil {
+				return
+			}
+
+			data, err := articleService.ExportArticlesCSV(c.Request.Context(), domain.ExportArticlesParams{
+				ArticleFilterParams: params,
+				Limit:               1000,
+			})
+			if err != nil {
+				writeServiceError(c, err)
+				return
+			}
+
+			c.Data(http.StatusOK, "text/csv; charset=utf-8", data)
 		})
 
 		v1.GET("/articles/:id", func(c *gin.Context) {
@@ -285,6 +292,52 @@ func parseOptionalBoolQuery(c *gin.Context, key string) (*bool, error) {
 	}
 
 	value, err := strconv.ParseBool(raw)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid " + key})
+		return nil, err
+	}
+	return &value, nil
+}
+
+func parseArticleFilterParams(c *gin.Context) (domain.ArticleFilterParams, error) {
+	sourceID, _ := strconv.ParseInt(c.Query("source_id"), 10, 64)
+	isRead, err := parseOptionalBoolQuery(c, "is_read")
+	if err != nil {
+		return domain.ArticleFilterParams{}, err
+	}
+	isFavorite, err := parseOptionalBoolQuery(c, "is_favorite")
+	if err != nil {
+		return domain.ArticleFilterParams{}, err
+	}
+	publishedFrom, err := parseOptionalTimeQuery(c, "from")
+	if err != nil {
+		return domain.ArticleFilterParams{}, err
+	}
+	publishedTo, err := parseOptionalTimeQuery(c, "to")
+	if err != nil {
+		return domain.ArticleFilterParams{}, err
+	}
+
+	return domain.ArticleFilterParams{
+		Query:         c.Query("q"),
+		Category:      c.Query("category"),
+		SourceID:      sourceID,
+		IsRead:        isRead,
+		IsFavorite:    isFavorite,
+		PublishedFrom: publishedFrom,
+		PublishedTo:   publishedTo,
+		Sort:          c.Query("sort"),
+		Order:         c.Query("order"),
+	}, nil
+}
+
+func parseOptionalTimeQuery(c *gin.Context, key string) (*time.Time, error) {
+	raw := c.Query(key)
+	if raw == "" {
+		return nil, nil
+	}
+
+	value, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid " + key})
 		return nil, err

--- a/services/article-service/internal/repository/article_repository.go
+++ b/services/article-service/internal/repository/article_repository.go
@@ -27,42 +27,8 @@ func (r *ArticleRepository) List(ctx context.Context, params domain.ListArticles
 	if params.PageSize < 1 || params.PageSize > 100 {
 		params.PageSize = 20
 	}
-	sortColumn := "COALESCE(a.published_at, a.fetched_at)"
-	if params.Sort == "created_at" {
-		sortColumn = "a.created_at"
-	}
-	order := "DESC"
-	if strings.EqualFold(params.Order, "asc") {
-		order = "ASC"
-	}
-
-	where := []string{"1=1"}
-	args := make([]any, 0)
-
-	if params.Query != "" {
-		where = append(where, "(a.title LIKE ? OR a.excerpt LIKE ?)")
-		q := "%" + params.Query + "%"
-		args = append(args, q, q)
-	}
-	if params.Category != "" {
-		where = append(where, "a.category = ?")
-		args = append(args, params.Category)
-	}
-	if params.SourceID > 0 {
-		where = append(where, "a.source_id = ?")
-		args = append(args, params.SourceID)
-	}
-	// 未読のみ・お気に入りのみを独立指定できる前提のため、bool 条件は個別に積み上げる。
-	if params.IsRead != nil {
-		where = append(where, "a.is_read = ?")
-		args = append(args, *params.IsRead)
-	}
-	if params.IsFavorite != nil {
-		where = append(where, "a.is_favorite = ?")
-		args = append(args, *params.IsFavorite)
-	}
-
-	whereClause := strings.Join(where, " AND ")
+	whereClause, args := buildArticleWhereClause(params.ArticleFilterParams)
+	sortColumn, order := buildArticleSortClause(params.ArticleFilterParams)
 	countQuery := fmt.Sprintf("SELECT COUNT(*) FROM articles a WHERE %s", whereClause)
 	var total int
 	if err := r.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
@@ -108,6 +74,45 @@ func (r *ArticleRepository) List(ctx context.Context, params domain.ListArticles
 		PageSize:   params.PageSize,
 		TotalPages: totalPages,
 	}, nil
+}
+
+func (r *ArticleRepository) Export(ctx context.Context, params domain.ExportArticlesParams) ([]domain.Article, error) {
+	limit := params.Limit
+	if limit < 1 {
+		limit = 1000
+	}
+
+	whereClause, args := buildArticleWhereClause(params.ArticleFilterParams)
+	sortColumn, order := buildArticleSortClause(params.ArticleFilterParams)
+	query := fmt.Sprintf(`
+		SELECT
+			a.id, a.title, a.url, a.source_id, s.name, a.published_at, a.fetched_at,
+			a.excerpt, a.category, a.tags, a.is_read, a.is_favorite, a.created_at, a.updated_at
+		FROM articles a
+		INNER JOIN sources s ON s.id = a.source_id
+		WHERE %s
+		ORDER BY %s %s
+		LIMIT ?`, whereClause, sortColumn, order)
+
+	// 上限超過は service 層で 400 に変換するため、limit+1 件だけ読んで検知する。
+	rows, err := r.db.QueryContext(ctx, query, append(args, limit+1)...)
+	if err != nil {
+		return nil, fmt.Errorf("export articles: %w", err)
+	}
+	defer rows.Close()
+
+	items := make([]domain.Article, 0)
+	for rows.Next() {
+		article, err := scanArticle(rows)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, article)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate export articles: %w", err)
+	}
+	return items, nil
 }
 
 func (r *ArticleRepository) GetByID(ctx context.Context, id int64) (*domain.Article, error) {
@@ -257,4 +262,54 @@ func RFC3339OrNow(raw string) time.Time {
 		return time.Now().UTC()
 	}
 	return parsed
+}
+
+func buildArticleWhereClause(params domain.ArticleFilterParams) (string, []any) {
+	where := []string{"1=1"}
+	args := make([]any, 0)
+
+	if params.Query != "" {
+		where = append(where, "(a.title LIKE ? OR a.excerpt LIKE ?)")
+		q := "%" + params.Query + "%"
+		args = append(args, q, q)
+	}
+	if params.Category != "" {
+		where = append(where, "a.category = ?")
+		args = append(args, params.Category)
+	}
+	if params.SourceID > 0 {
+		where = append(where, "a.source_id = ?")
+		args = append(args, params.SourceID)
+	}
+	// 未読のみ・お気に入りのみを独立指定できる前提のため、bool 条件は個別に積み上げる。
+	if params.IsRead != nil {
+		where = append(where, "a.is_read = ?")
+		args = append(args, *params.IsRead)
+	}
+	if params.IsFavorite != nil {
+		where = append(where, "a.is_favorite = ?")
+		args = append(args, *params.IsFavorite)
+	}
+	if params.PublishedFrom != nil {
+		where = append(where, "a.published_at IS NOT NULL", "a.published_at >= ?")
+		args = append(args, params.PublishedFrom.UTC())
+	}
+	if params.PublishedTo != nil {
+		where = append(where, "a.published_at IS NOT NULL", "a.published_at <= ?")
+		args = append(args, params.PublishedTo.UTC())
+	}
+
+	return strings.Join(where, " AND "), args
+}
+
+func buildArticleSortClause(params domain.ArticleFilterParams) (string, string) {
+	sortColumn := "COALESCE(a.published_at, a.fetched_at)"
+	if params.Sort == "created_at" {
+		sortColumn = "a.created_at"
+	}
+	order := "DESC"
+	if strings.EqualFold(params.Order, "asc") {
+		order = "ASC"
+	}
+	return sortColumn, order
 }

--- a/services/article-service/internal/service/article_service.go
+++ b/services/article-service/internal/service/article_service.go
@@ -1,7 +1,9 @@
 package service
 
 import (
+	"bytes"
 	"context"
+	"encoding/csv"
 	"errors"
 	"fmt"
 	"net/url"
@@ -39,6 +41,7 @@ type ArticleService struct {
 
 type articleRepository interface {
 	List(ctx context.Context, params domain.ListArticlesParams) (domain.ListArticlesResult, error)
+	Export(ctx context.Context, params domain.ExportArticlesParams) ([]domain.Article, error)
 	GetByID(ctx context.Context, id int64) (*domain.Article, error)
 	UpdateReadStatus(ctx context.Context, id int64, isRead bool) (*domain.Article, error)
 	UpdateFavoriteStatus(ctx context.Context, id int64, isFavorite bool) (*domain.Article, error)
@@ -82,7 +85,60 @@ func (s *ArticleService) ListFetchJobs(ctx context.Context, params domain.ListFe
 }
 
 func (s *ArticleService) ListArticles(ctx context.Context, params domain.ListArticlesParams) (domain.ListArticlesResult, error) {
+	if err := validateArticleFilters(params.ArticleFilterParams); err != nil {
+		return domain.ListArticlesResult{}, err
+	}
 	return s.articleRepo.List(ctx, params)
+}
+
+func (s *ArticleService) ExportArticlesCSV(ctx context.Context, params domain.ExportArticlesParams) ([]byte, error) {
+	if err := validateArticleFilters(params.ArticleFilterParams); err != nil {
+		return nil, err
+	}
+	if params.Limit < 1 {
+		params.Limit = 1000
+	}
+
+	articles, err := s.articleRepo.Export(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	if len(articles) > params.Limit {
+		return nil, newServiceError(ErrValidation, fmt.Sprintf("export result exceeds limit %d", params.Limit))
+	}
+
+	var buf bytes.Buffer
+	buf.Write([]byte{0xEF, 0xBB, 0xBF})
+	writer := csv.NewWriter(&buf)
+	if err := writer.Write([]string{
+		"title", "url", "source_name", "category", "published_at",
+		"fetched_at", "is_read", "is_favorite", "excerpt", "tags",
+	}); err != nil {
+		return nil, fmt.Errorf("write csv header: %w", err)
+	}
+
+	for _, article := range articles {
+		record := []string{
+			sanitizeCSVCell(article.Title),
+			sanitizeCSVCell(article.URL),
+			sanitizeCSVCell(article.SourceName),
+			sanitizeCSVCell(article.Category),
+			formatCSVTime(article.PublishedAt),
+			formatCSVTime(&article.FetchedAt),
+			formatCSVBool(article.IsRead),
+			formatCSVBool(article.IsFavorite),
+			sanitizeCSVCell(article.Excerpt),
+			sanitizeCSVCell(strings.Join(article.Tags, ";")),
+		}
+		if err := writer.Write(record); err != nil {
+			return nil, fmt.Errorf("write csv record: %w", err)
+		}
+	}
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return nil, fmt.Errorf("flush csv: %w", err)
+	}
+	return buf.Bytes(), nil
 }
 
 func (s *ArticleService) GetArticle(ctx context.Context, id int64) (*domain.Article, error) {
@@ -443,4 +499,37 @@ func normalizeOptionalString(value *string) *string {
 		return nil
 	}
 	return &trimmed
+}
+
+func validateArticleFilters(params domain.ArticleFilterParams) error {
+	if params.PublishedFrom != nil && params.PublishedTo != nil && params.PublishedFrom.After(*params.PublishedTo) {
+		return newServiceError(ErrValidation, "from must be less than or equal to to")
+	}
+	return nil
+}
+
+func formatCSVTime(value *time.Time) string {
+	if value == nil {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339)
+}
+
+func formatCSVBool(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
+}
+
+func sanitizeCSVCell(value string) string {
+	if value == "" {
+		return ""
+	}
+	switch value[0] {
+	case '=', '+', '-', '@', '\t', '\r', '\n':
+		return "'" + value
+	default:
+		return value
+	}
 }

--- a/services/article-service/internal/service/article_service_test.go
+++ b/services/article-service/internal/service/article_service_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 
 type stubArticleRepo struct {
 	listFunc                 func(ctx context.Context, params domain.ListArticlesParams) (domain.ListArticlesResult, error)
+	exportFunc               func(ctx context.Context, params domain.ExportArticlesParams) ([]domain.Article, error)
 	getByIDFunc              func(ctx context.Context, id int64) (*domain.Article, error)
 	updateReadStatusFunc     func(ctx context.Context, id int64, isRead bool) (*domain.Article, error)
 	updateFavoriteStatusFunc func(ctx context.Context, id int64, isFavorite bool) (*domain.Article, error)
@@ -22,6 +24,13 @@ func (r *stubArticleRepo) List(ctx context.Context, params domain.ListArticlesPa
 		return r.listFunc(ctx, params)
 	}
 	return domain.ListArticlesResult{}, nil
+}
+
+func (r *stubArticleRepo) Export(ctx context.Context, params domain.ExportArticlesParams) ([]domain.Article, error) {
+	if r.exportFunc != nil {
+		return r.exportFunc(ctx, params)
+	}
+	return nil, nil
 }
 
 func (r *stubArticleRepo) GetByID(ctx context.Context, id int64) (*domain.Article, error) {
@@ -307,8 +316,10 @@ func TestListArticlesPassesReadAndFavoriteFilters(t *testing.T) {
 	}
 
 	_, err := service.ListArticles(context.Background(), domain.ListArticlesParams{
-		IsRead:     &isRead,
-		IsFavorite: &isFavorite,
+		ArticleFilterParams: domain.ArticleFilterParams{
+			IsRead:     &isRead,
+			IsFavorite: &isFavorite,
+		},
 	})
 	if err != nil {
 		t.Fatalf("ListArticles returned error: %v", err)
@@ -376,5 +387,142 @@ func TestUpdateFavoriteStatusReturnsNotFoundWhenArticleMissing(t *testing.T) {
 	_, err := service.UpdateFavoriteStatus(context.Background(), 8, UpdateFavoriteStatusInput{IsFavorite: true})
 	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+func TestExportArticlesCSVFormatsRowsAndPassesFilters(t *testing.T) {
+	t.Parallel()
+
+	isFavorite := true
+	from := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 4, 30, 23, 59, 59, 0, time.UTC)
+	publishedAt := time.Date(2026, 4, 14, 12, 34, 56, 0, time.UTC)
+	fetchedAt := time.Date(2026, 4, 14, 12, 35, 10, 0, time.UTC)
+
+	service := &ArticleService{
+		articleRepo: &stubArticleRepo{
+			exportFunc: func(_ context.Context, params domain.ExportArticlesParams) ([]domain.Article, error) {
+				if params.SourceID != 9 {
+					t.Fatalf("unexpected source_id: %d", params.SourceID)
+				}
+				if params.IsFavorite == nil || *params.IsFavorite != isFavorite {
+					t.Fatalf("unexpected is_favorite: %#v", params.IsFavorite)
+				}
+				if params.PublishedFrom == nil || !params.PublishedFrom.Equal(from) {
+					t.Fatalf("unexpected from: %#v", params.PublishedFrom)
+				}
+				if params.PublishedTo == nil || !params.PublishedTo.Equal(to) {
+					t.Fatalf("unexpected to: %#v", params.PublishedTo)
+				}
+				return []domain.Article{{
+					Title:       "=danger",
+					URL:         "https://example.com/articles/1",
+					SourceName:  "Kubernetes Blog",
+					Category:    "kubernetes",
+					PublishedAt: &publishedAt,
+					FetchedAt:   fetchedAt,
+					IsRead:      false,
+					IsFavorite:  true,
+					Excerpt:     "@formula",
+					Tags:        []string{"go", "k8s"},
+				}}, nil
+			},
+		},
+		sourceRepo: &stubSourceRepo{
+			ensureSourceFunc:      func(context.Context, domain.Source) (int64, error) { return 0, nil },
+			updateFetchStatusFunc: func(context.Context, int64, string, *string) error { return nil },
+		},
+		jobRepo: &stubJobRepo{
+			createFunc:  func(context.Context, int64) (int64, error) { return 0, nil },
+			getByIDFunc: func(context.Context, int64) (*domain.FetchJob, error) { return nil, nil },
+			listFunc: func(context.Context, domain.ListFetchJobsParams) (domain.ListFetchJobsResult, error) {
+				return domain.ListFetchJobsResult{}, nil
+			},
+			finishFunc: func(context.Context, int64, string, int, int, int, *string) error { return nil },
+		},
+	}
+
+	data, err := service.ExportArticlesCSV(context.Background(), domain.ExportArticlesParams{
+		ArticleFilterParams: domain.ArticleFilterParams{
+			SourceID:      9,
+			IsFavorite:    &isFavorite,
+			PublishedFrom: &from,
+			PublishedTo:   &to,
+		},
+		Limit: 1000,
+	})
+	if err != nil {
+		t.Fatalf("ExportArticlesCSV returned error: %v", err)
+	}
+
+	got := string(data)
+	if !strings.HasPrefix(got, "\uFEFFtitle,url,source_name,category,published_at,fetched_at,is_read,is_favorite,excerpt,tags\n") {
+		t.Fatalf("unexpected csv header: %q", got)
+	}
+	if !strings.Contains(got, "'=danger,https://example.com/articles/1,Kubernetes Blog,kubernetes,2026-04-14T12:34:56Z,2026-04-14T12:35:10Z,false,true,'@formula,go;k8s\n") {
+		t.Fatalf("unexpected csv row: %q", got)
+	}
+}
+
+func TestExportArticlesCSVRejectsInvalidDateRange(t *testing.T) {
+	t.Parallel()
+
+	from := time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 4, 19, 0, 0, 0, 0, time.UTC)
+
+	service := &ArticleService{
+		articleRepo: &stubArticleRepo{},
+		sourceRepo: &stubSourceRepo{
+			ensureSourceFunc:      func(context.Context, domain.Source) (int64, error) { return 0, nil },
+			updateFetchStatusFunc: func(context.Context, int64, string, *string) error { return nil },
+		},
+		jobRepo: &stubJobRepo{
+			createFunc:  func(context.Context, int64) (int64, error) { return 0, nil },
+			getByIDFunc: func(context.Context, int64) (*domain.FetchJob, error) { return nil, nil },
+			listFunc: func(context.Context, domain.ListFetchJobsParams) (domain.ListFetchJobsResult, error) {
+				return domain.ListFetchJobsResult{}, nil
+			},
+			finishFunc: func(context.Context, int64, string, int, int, int, *string) error { return nil },
+		},
+	}
+
+	_, err := service.ExportArticlesCSV(context.Background(), domain.ExportArticlesParams{
+		ArticleFilterParams: domain.ArticleFilterParams{
+			PublishedFrom: &from,
+			PublishedTo:   &to,
+		},
+		Limit: 1000,
+	})
+	if !errors.Is(err, ErrValidation) {
+		t.Fatalf("expected ErrValidation, got: %v", err)
+	}
+}
+
+func TestExportArticlesCSVRejectsResultOverLimit(t *testing.T) {
+	t.Parallel()
+
+	service := &ArticleService{
+		articleRepo: &stubArticleRepo{
+			exportFunc: func(context.Context, domain.ExportArticlesParams) ([]domain.Article, error) {
+				return []domain.Article{{Title: "1"}, {Title: "2"}}, nil
+			},
+		},
+		sourceRepo: &stubSourceRepo{
+			ensureSourceFunc:      func(context.Context, domain.Source) (int64, error) { return 0, nil },
+			updateFetchStatusFunc: func(context.Context, int64, string, *string) error { return nil },
+		},
+		jobRepo: &stubJobRepo{
+			createFunc:  func(context.Context, int64) (int64, error) { return 0, nil },
+			getByIDFunc: func(context.Context, int64) (*domain.FetchJob, error) { return nil, nil },
+			listFunc: func(context.Context, domain.ListFetchJobsParams) (domain.ListFetchJobsResult, error) {
+				return domain.ListFetchJobsResult{}, nil
+			},
+			finishFunc: func(context.Context, int64, string, int, int, int, *string) error { return nil },
+		},
+	}
+
+	_, err := service.ExportArticlesCSV(context.Background(), domain.ExportArticlesParams{Limit: 1})
+	if !errors.Is(err, ErrValidation) {
+		t.Fatalf("expected ErrValidation, got: %v", err)
 	}
 }


### PR DESCRIPTION
## 概要

- 記事一覧の現在条件を使って CSV をダウンロードできるようにしました
- article-service / api-gateway / frontend をまたいで CSV 出力経路を追加しました

## 背景 / 目的

- Issue #4 の CSV 出力を実装し、検索・フィルタ結果をそのまま二次利用できるようにするため
- 既存の一覧条件と CSV 条件の不一致を避けるため

## 変更内容

- article-service に記事エクスポート用 CSV API と CSV 生成ロジックを追加
- 一覧 API と CSV API で共通の filter params を使うように整理
- `from` / `to` による `published_at` 範囲フィルタを追加
- UTF-8 BOM、Excel 向け危険文字エスケープ、1000件上限を実装
- api-gateway に `GET /api/v1/exports/articles.csv` を追加し、ダウンロードヘッダを gateway 側で制御
- frontend の記事一覧画面に source / 公開日範囲フィルタと CSV Download 導線を追加
- OpenAPI と関連 docs を更新

## 影響範囲

- [x] frontend
- [x] api-gateway
- [ ] collector-service
- [x] article-service
- [ ] notification-service
- [ ] infra
- [x] docs

## 検証

- [x] `go test ./...`
- [x] `npm run build`
- [x] `docker compose config -q`
- [x] その他: `make verify`

## API / DB / Infra への影響

- [x] API を変更した
- [ ] DB schema を変更した
- [ ] Compose を変更した
- [ ] Kubernetes / Helm を変更した
- [ ] 大きな影響はない

## ドキュメント

- [ ] 必要に応じて `RULES.md` を更新した
- [x] 関連する `docs/` を更新した
- [ ] ドキュメント更新は不要

## リスク / 注意点

- `feature/read-favorite-management` を base にしています。既読 / お気に入り機能の差分が先に必要なため、base branch マージ後は `main` へ retarget してください
- 日付範囲は `published_at` 基準で、`published_at` がない記事は範囲指定時に対象外になります

## 補足

- ソース内コメントは確認し、責務境界と上限検知の意図が読み取りにくい 2 箇所だけ補記しました
