### PR TITLE
docs: 進捗ドキュメントを現状に同期

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -51,7 +51,7 @@
 
 ## Current Phase
 
-現在は Phase 1 完了後、Phase 2 着手前です。
+現在は Phase 2 の主要機能実装が完了し、Phase 3 着手前です。
 
 Phase 1 で完了した範囲:
 
@@ -62,12 +62,22 @@ Phase 1 で完了した範囲:
 - MySQL 接続
 - 記事一覧 / 詳細 / 検索
 
-次フェーズでは以下を追加します。
+Phase 2 で完了した範囲:
 
-- ソース管理
 - 既読 / お気に入り
+- ソース管理
 - CSV 出力
 - 取得ジョブ履歴
+
+現在の残課題:
+
+- collector-service はまだ静的設定ベースで、source 管理 API とは未連携
+
+次フェーズでは以下を追加します。
+
+- notification-service の実装
+- RabbitMQ 連携
+- 取得失敗通知とダイジェストの導入
 
 ## Service Responsibilities
 
@@ -221,8 +231,7 @@ npm run build
 
 次に着手する優先順は以下です。
 
-1. article-service にソース管理 API を追加
-2. article-service に既読 / お気に入り更新 API を追加
-3. CSV 出力 API を api-gateway 経由で追加
-4. fetch job history 一覧 API を追加
-5. frontend に管理画面を追加
+1. notification-service と RabbitMQ 連携を実装
+2. collector-service の動的ソース同期を進める
+3. Compose 整備、GitHub Actions、OpenAPI 保守を進める
+4. kind / Helm / Argo CD の整備に着手する

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 
 ### Changed
 
-- `AGENT.md` と `README.md` の現在地を Phase 1 完了後の状態に同期
-- `docs/current-status.md` と `docs/known-issues.md` をソース管理実装後の状態に更新
+- 進捗系ドキュメントを Phase 2 の主要機能実装後、Phase 3 着手前の状態に同期
+- `docs/current-status.md` の Open GitHub Issues を現行の open issue に更新
+- `docs/backlog-priority.md` の優先順位を現状の残課題と open issue に合わせて更新
 - 記事一覧 API と CSV エクスポートで `source_id`, `from`, `to` を含む共通フィルタを利用
 - `api-gateway` の CSV API 方針を `GET /api/v1/exports/articles.csv` に統一
 

--- a/README.md
+++ b/README.md
@@ -13,20 +13,22 @@ DevOps / インフラ / クラウド / SRE / CI/CD 関連の技術情報を定�
 - `deployments/k8s`: kind / Helm / Argo CD 向け土台
 - `docs`: API設計・フェーズ計画
 
-## Phase 1
+## Current Status
 
-Phase 1 では以下を実装対象とします。
+Phase 1 の記事閲覧フローに加えて、Phase 2 の主要機能も実装済みです。
 
-- article-service
-- collector-service の最小収集フロー
-- api-gateway
-- frontend
+- article-service / collector-service / api-gateway / frontend
 - MySQL 接続
 - 記事一覧 / 詳細 / 検索
+- 既読 / お気に入り管理
+- ソース管理
+- 記事検索結果の CSV 出力
+- 取得ジョブ履歴の表示
 
 現在地:
 
-- Phase 1 完了後、Phase 2 着手前
+- Phase 2 の主要機能実装が完了し、Phase 3 着手前
+- collector-service はまだ静的 source 設定依存
 - 検証状態の詳細は `docs/current-status.md` を参照
 
 ## Planned Repository Structure

--- a/docs/backlog-priority.md
+++ b/docs/backlog-priority.md
@@ -8,20 +8,19 @@
 
 ### Now
 
-1. `#1` ソース管理 API と UI の実装
-2. `#2` 取得ジョブ履歴と失敗状況の可視化
-3. `#3` 既読 / お気に入り管理の実装
-4. `#4` 記事検索結果の CSV 出力実装
+1. collector-service の動的ソース同期
+2. `#8` notification-service と RabbitMQ 連携の実装
+3. `#5` Compose 整備、GitHub Actions、OpenAPI 保守
 
 ### Next
 
-5. `#8` notification-service と RabbitMQ 連携の実装
-6. `#5` Compose 整備、GitHub Actions、OpenAPI 保守
+4. `#7` kind デプロイ、Helm Chart、Argo CD の整備
+5. `#6` Proxmox クラスタ移行、永続化、監視拡張
 
 ### Later
 
-7. `#7` kind デプロイ、Helm Chart、Argo CD の整備
-8. `#6` Proxmox クラスタ移行、永続化、監視拡張
+6. 認証導入
+7. 監視基盤の詳細設計
 
 ## Priority Rules
 

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -6,7 +6,7 @@
 
 ## Current Phase
 
-- 現在は Phase 2 実装中
+- 現在は Phase 2 の主要機能実装が完了し、Phase 3 着手前
 
 ## What Is Already Implemented
 
@@ -45,16 +45,13 @@
 
 ## Highest Priority Next
 
-1. collector-service のソース管理連携
-2. notification-service と RabbitMQ 連携
+1. notification-service と RabbitMQ 連携
+2. collector-service の動的ソース同期
 3. Compose 整備、GitHub Actions、OpenAPI 保守
 4. kind / Helm / Argo CD の整備
 
 ## Open GitHub Issues
 
-- `#2` `[Phase 2] 取得ジョブ履歴と失敗状況の可視化`
-- `#3` `[Phase 2] 既読 / お気に入り管理の実装`
-- `#4` `[Phase 2] 記事検索結果の CSV 出力実装`
 - `#8` `[Phase 3] notification-service と RabbitMQ 連携の実装`
 - `#5` `[Phase 4] Compose 整備、GitHub Actions、OpenAPI 保守`
 - `#7` `[Phase 5] kind デプロイ、Helm Chart、Argo CD の整備`

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -19,11 +19,6 @@
 - api-gateway に JWT の導入ポイントはあるが、実装は未着手
 - 初期は単一ユーザー前提のため後ろ倒し
 
-### CSV Export Is Not Implemented Yet
-
-- 要件にはあるが、現状は記事一覧 / 詳細 / 検索まで
-- Phase 2 の `#4` で対応予定
-
 ### Notification Flow Is Not Implemented Yet
 
 - notification-service は health endpoint のみ


### PR DESCRIPTION
## 概要
- 進捗系ドキュメントを Phase 2 の主要機能実装後の状態に同期
- current status / backlog / known issues を現在の実装状況と open issue に合わせて整理
- README と AGENT の現在地を Phase 3 着手前に更新

## 変更内容
- `AGENT.md` の Current Phase と次着手項目を更新
- `README.md` の現在地を Phase 2 主要機能実装済みに更新
- `docs/current-status.md` の current phase / 優先タスク / open issues を更新
- `docs/backlog-priority.md` の優先順位を残課題ベースに更新
- `docs/known-issues.md` から解消済みの CSV 未実装項目を削除
- `CHANGELOG.md` に進捗ドキュメント同期を追記

## 影響範囲
- docs のみ

## 検証
- docs-only 変更のためテスト未実施
- GitHub の open issue 状態を確認して反映済み

## docs 更新
- あり