### PR TITLE
Phase 4 の Compose / OpenAPI / 運用ドキュメントを整備

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -122,8 +122,9 @@ Phase 4 で完了した範囲:
 
 ### notification-service
 
-- まだ雛形のみ
-- 後続フェーズで通知条件判定、ダイジェスト、Slack / メール連携を追加
+- 通知一覧 / 既読更新 API
+- RabbitMQ 経由の新着通知 / 取得失敗通知
+- 後続フェーズで日次 / 週次ダイジェスト、Slack / メール連携を追加
 
 ## Local Development
 
@@ -230,6 +231,9 @@ npm run build
 - `.env.example` を最新に保つ
 - `node_modules`, `dist`, `*.tsbuildinfo` はコミットしない
 - ドキュメント更新を伴う設計変更では `docs/` も更新する
+- Git のコミットメッセージは日本語で記述する
+- Pull Request の題名と本文は、明示的な指示がない限り日本語で記述する
+- Pull Request 作成時は `.github/pull_request_template.md` を使い、各項目を実施内容に合わせて埋める
 
 ## Documentation Update Rules
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -51,7 +51,7 @@
 
 ## Current Phase
 
-現在は Phase 2 の主要機能実装が完了し、Phase 3 着手前です。
+現在は Phase 4 の Compose / CI / OpenAPI 整備まで実装済みです。
 
 Phase 1 で完了した範囲:
 
@@ -69,15 +69,27 @@ Phase 2 で完了した範囲:
 - CSV 出力
 - 取得ジョブ履歴
 
+Phase 3 で完了した範囲:
+
+- notification-service
+- RabbitMQ 連携
+- 新着通知と取得失敗通知
+
+Phase 4 で完了した範囲:
+
+- Docker Compose のローカル運用整備
+- GitHub Actions の最小 CI
+- OpenAPI の公開 API 追従
+
 現在の残課題:
 
 - collector-service はまだ静的設定ベースで、source 管理 API とは未連携
 
-次フェーズでは以下を追加します。
+次に優先して進める内容は以下です。
 
-- notification-service の実装
-- RabbitMQ 連携
-- 取得失敗通知とダイジェストの導入
+- collector-service の動的ソース同期
+- kind / Helm / Argo CD の整備
+- Proxmox クラスタ移行、永続化、監視拡張
 
 ## Service Responsibilities
 
@@ -140,6 +152,12 @@ make up
 
 ```bash
 make down
+```
+
+volume も含めて初期化したい場合:
+
+```bash
+make reset
 ```
 
 ## Verification
@@ -231,7 +249,7 @@ npm run build
 
 次に着手する優先順は以下です。
 
-1. notification-service と RabbitMQ 連携を実装
-2. collector-service の動的ソース同期を進める
-3. Compose 整備、GitHub Actions、OpenAPI 保守を進める
-4. kind / Helm / Argo CD の整備に着手する
+1. collector-service の動的ソース同期を進める
+2. kind / Helm / Argo CD の整備に着手する
+3. Proxmox クラスタ移行、永続化、監視拡張を進める
+4. 認証導入の前提整理を進める

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
 -include .env
 
-.PHONY: up down logs ps build test verify
+.PHONY: up down reset logs ps build test verify
 
 up:
 	docker compose up --build
 
 down:
+	docker compose down
+
+reset:
 	docker compose down -v
 
 logs:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ DevOps / インフラ / クラウド / SRE / CI/CD 関連の技術情報を定�
 
 ## Current Status
 
-Phase 1 の記事閲覧フローに加えて、Phase 2 の主要機能と Phase 3 の最初の非同期通知経路を実装済みです。
+Phase 1 の記事閲覧フローに加えて、Phase 2 の主要機能、Phase 3 の通知経路、Phase 4 の基盤整備を実装済みです。
 
 - article-service / collector-service / api-gateway / frontend
 - MySQL 接続
@@ -26,10 +26,13 @@ Phase 1 の記事閲覧フローに加えて、Phase 2 の主要機能と Phase 
 - 取得ジョブ履歴の表示
 - RabbitMQ 経由の通知生成
 - 通知一覧 / 既読更新
+- Docker Compose のローカル運用整備
+- GitHub Actions の最小 CI
+- OpenAPI の公開 API 追従
 
 現在地:
 
-- Phase 3 の notification-service / RabbitMQ 連携が実装済み
+- Phase 4 の Compose / CI / OpenAPI 整備まで実装済み
 - collector-service はまだ静的 source 設定依存
 - 検証状態の詳細は `docs/current-status.md` を参照
 
@@ -72,6 +75,9 @@ Phase 1 の記事閲覧フローに加えて、Phase 2 の主要機能と Phase 
 
 ## Standard Commands
 
+- `make up`: 全サービス起動
+- `make down`: volume を残して停止
+- `make reset`: volume を削除して初期化
 - `make build`: frontend build
 - `make test`: backend test
 - `make verify`: test + build + compose config check
@@ -80,3 +86,4 @@ Phase 1 の記事閲覧フローに加えて、Phase 2 の主要機能と Phase 
 
 - 通常のコード変更では CI も `make verify` 相当を実行します
 - docs-only 変更では、GitHub Actions は required check を維持しつつ重い検証を省略します
+- collector-service の source 定義は現時点では Compose 上の静的設定です

--- a/RULES.md
+++ b/RULES.md
@@ -138,6 +138,8 @@
 - `.env.example` は常に最新に保つ
 - Git のコミットメッセージは日本語で記述する
 - Pull Request の題名と本文は、明示的な指示がない限り日本語で記述する
+- Pull Request 作成時は `.github/pull_request_template.md` を使用し、空欄のまま提出しない
+- Pull Request の検証欄、影響欄、ドキュメント欄は実施内容に合わせて更新する
 - 明示的な指示がない限り `main` へ直接 push しない
 - 基本運用は feature branch + Pull Request とする
 - release branch は明示的な指示がない限り切らない

--- a/docs/backlog-priority.md
+++ b/docs/backlog-priority.md
@@ -9,18 +9,18 @@
 ### Now
 
 1. collector-service の動的ソース同期
-2. `#8` notification-service と RabbitMQ 連携の実装
-3. `#5` Compose 整備、GitHub Actions、OpenAPI 保守
+2. `#7` kind デプロイ、Helm Chart、Argo CD の整備
+3. `#6` Proxmox クラスタ移行、永続化、監視拡張
 
 ### Next
 
-4. `#7` kind デプロイ、Helm Chart、Argo CD の整備
-5. `#6` Proxmox クラスタ移行、永続化、監視拡張
+4. 認証導入
+5. 監視基盤の詳細設計
 
 ### Later
 
-6. 認証導入
-7. 監視基盤の詳細設計
+6. バックアップ / リストア運用の整理
+7. collector の収集戦略拡張
 
 ## Priority Rules
 

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -6,7 +6,7 @@
 
 ## Current Phase
 
-- 現在は Phase 3 の notification-service / RabbitMQ 連携まで実装済み
+- 現在は Phase 4 の Compose / GitHub Actions / OpenAPI 整備まで実装済み
 
 ## What Is Already Implemented
 
@@ -33,11 +33,12 @@
 - `frontend` の通知一覧画面
 - RabbitMQ 経由の新着通知 / 取得失敗通知フロー
 - MySQL 初期スキーマ
-- Docker Compose 起動基盤
+- Docker Compose のローカル運用整備
 - ルール / 要件 / ガイドライン / ADR のドキュメント群
 - GitHub Issue / PR テンプレート
 - GitHub Actions の最小 CI
 - collector-service / api-gateway の最小ユニットテスト
+- OpenAPI の公開 API 追従
 
 ## Verified State
 
@@ -49,13 +50,12 @@
 ## Highest Priority Next
 
 1. collector-service の動的ソース同期
-2. Compose 整備、GitHub Actions、OpenAPI 保守
-3. kind / Helm / Argo CD の整備
-4. Proxmox クラスタ移行、永続化、監視拡張
+2. kind / Helm / Argo CD の整備
+3. Proxmox クラスタ移行、永続化、監視拡張
+4. 認証導入の設計整理
 
 ## Open GitHub Issues
 
-- `#5` `[Phase 4] Compose 整備、GitHub Actions、OpenAPI 保守`
 - `#7` `[Phase 5] kind デプロイ、Helm Chart、Argo CD の整備`
 - `#6` `[Phase 6] Proxmox クラスタ移行、永続化、監視拡張`
 

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -19,12 +19,6 @@
 - api-gateway に JWT の導入ポイントはあるが、実装は未着手
 - 初期は単一ユーザー前提のため後ろ倒し
 
-### Notification Flow Is Not Implemented Yet
-
-- notification-service は health endpoint のみ
-- RabbitMQ も未接続
-- Phase 3 の `#8` で対応予定
-
 ### Kubernetes Delivery Is Not Implemented Yet
 
 - `deployments/k8s` はプレースホルダのみ

--- a/docs/openapi/api-gateway.yaml
+++ b/docs/openapi/api-gateway.yaml
@@ -293,7 +293,6 @@ paths:
       parameters:
         - in: query
           name: source_id
-          required: true
           schema:
             type: integer
         - in: query
@@ -323,6 +322,60 @@ paths:
                 $ref: "#/components/schemas/ListFetchJobsResponse"
         "400":
           description: Validation error
+  /api/v1/notifications:
+    get:
+      summary: List notifications
+      parameters:
+        - in: query
+          name: is_read
+          schema:
+            type: boolean
+        - in: query
+          name: page
+          schema:
+            type: integer
+            default: 1
+        - in: query
+          name: page_size
+          schema:
+            type: integer
+            default: 20
+            maximum: 100
+      responses:
+        "200":
+          description: Notification list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListNotificationsResponse"
+        "400":
+          description: Validation error
+  /api/v1/notifications/{id}/read-status:
+    patch:
+      summary: Update notification read status
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReadStatusInput"
+      responses:
+        "200":
+          description: Updated notification
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Notification"
+        "400":
+          description: Validation error
+        "404":
+          description: Notification not found
 components:
   schemas:
     Article:
@@ -540,6 +593,72 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/FetchJob"
+        total:
+          type: integer
+        page:
+          type: integer
+        page_size:
+          type: integer
+        total_pages:
+          type: integer
+      required:
+        - items
+        - total
+        - page
+        - page_size
+        - total_pages
+    Notification:
+      type: object
+      properties:
+        id:
+          type: integer
+        event_id:
+          type: string
+        event_type:
+          type: string
+          enum:
+            - article.ingested
+            - collector.fetch.failed
+        level:
+          type: string
+          enum:
+            - info
+            - error
+        title:
+          type: string
+        body:
+          type: string
+        source_id:
+          type: integer
+          nullable: true
+        fetch_job_id:
+          type: integer
+          nullable: true
+        is_read:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+        read_at:
+          type: string
+          format: date-time
+          nullable: true
+      required:
+        - id
+        - event_id
+        - event_type
+        - level
+        - title
+        - body
+        - is_read
+        - created_at
+    ListNotificationsResponse:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/Notification"
         total:
           type: integer
         page:

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -30,6 +30,11 @@ make up
 make down
 ```
 
+補足:
+
+- `make down` は named volume を削除しない
+- DB を含めて初期化したい場合だけ `make reset` を使う
+
 ### Logs
 
 ```bash
@@ -59,6 +64,12 @@ npm run build
 
 ```bash
 docker compose config -q
+```
+
+### Full Verify
+
+```bash
+make verify
 ```
 
 ## Health Endpoints


### PR DESCRIPTION
## 概要

- `make down` を非破壊停止に変更し、初期化は `make reset` に分離した
- Phase 4 完了に合わせて README / AGENT / current-status / backlog / known-issues / runbook を更新した
- API Gateway の OpenAPI を現行の公開 API に追従させ、通知 API と `fetch-jobs` の実装差分を解消した
- 今後の PR 作成でテンプレートと日本語記述を徹底できるよう、`RULES.md` と `AGENT.md` に明記した

## 背景 / 目的

- Issue `#5` の完了条件である Compose 整備、GitHub Actions 運用前提の明文化、OpenAPI 保守を反映するため
- 実装状態と運用ドキュメントのズレをなくし、次セッションでも同じ運用ルールで進められるようにするため

## 変更内容

- `Makefile` の停止系ターゲットを整理し、通常停止では named volume を残すようにした
- `README.md` と `docs/runbook.md` に `make down` / `make reset` / `make verify` の運用を追記した
- `AGENT.md`, `docs/current-status.md`, `docs/backlog-priority.md`, `docs/known-issues.md` を現在のフェーズ進行に合わせて更新した
- `docs/openapi/api-gateway.yaml` に `GET /api/v1/notifications`, `PATCH /api/v1/notifications/{id}/read-status` を追加し、`GET /api/v1/fetch-jobs` の `source_id` を任意に修正した
- `RULES.md` と `AGENT.md` に、PR は `.github/pull_request_template.md` を使い日本語で記述する運用を追加した

## 影響範囲

- infra
- docs

## 検証

- [x] `go test ./...`
- [x] `npm run build`
- [x] `docker compose config -q`
- [x] その他: `make verify`

## API / DB / Infra への影響

- [ ] API を変更した
- [ ] DB schema を変更した
- [ ] Compose を変更した
- [ ] Kubernetes / Helm を変更した
- [x] 大きな影響はない

## ドキュメント

- [x] 必要に応じて `RULES.md` を更新した
- [x] 関連する `docs/` を更新した
- [ ] ドキュメント更新は不要

## リスク / 注意点

- これまで `make down` で初期化される前提で使っていた場合は、今後は `make reset` を明示的に使う必要がある
- OpenAPI の更新は実装追従であり、API の挙動自体は変更していない

## 補足

- Closes #5