### PR TITLE
collector-service の動的ソース同期を実装

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -234,6 +234,9 @@ npm run build
 - Git のコミットメッセージは日本語で記述する
 - Pull Request の題名と本文は、明示的な指示がない限り日本語で記述する
 - Pull Request 作成時は `.github/pull_request_template.md` を使い、各項目を実施内容に合わせて埋める
+- Pull Request 作成前に `.github/pull_request_template.md` を必ず開いて内容を確認する
+- GitHub API / MCP で Pull Request を作成する場合、テンプレートは自動適用されない前提で扱い、テンプレートを元にした本文を自分で組み立てて渡す
+- Pull Request 作成直後に、題名が日本語であることと、本文がテンプレートの主要項目を満たしていることを確認し、不足があればその場で更新する
 
 ## Documentation Update Rules
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -83,11 +83,11 @@ Phase 4 で完了した範囲:
 
 現在の残課題:
 
-- collector-service はまだ静的設定ベースで、source 管理 API とは未連携
+- kind / Helm / Argo CD の整備
+- Proxmox クラスタ移行、永続化、監視拡張
 
 次に優先して進める内容は以下です。
 
-- collector-service の動的ソース同期
 - kind / Helm / Argo CD の整備
 - Proxmox クラスタ移行、永続化、監視拡張
 
@@ -253,7 +253,7 @@ npm run build
 
 次に着手する優先順は以下です。
 
-1. collector-service の動的ソース同期を進める
-2. kind / Helm / Argo CD の整備に着手する
-3. Proxmox クラスタ移行、永続化、監視拡張を進める
-4. 認証導入の前提整理を進める
+1. kind / Helm / Argo CD の整備に着手する
+2. Proxmox クラスタ移行、永続化、監視拡張を進める
+3. 認証導入の前提整理を進める
+4. collector の収集戦略拡張を進める

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- collector-service が `COLLECTOR_SOURCES_JSON` ではなく article-service の source 管理 API を実行時参照する構成に移行
+- collector-service の収集実行が source の `is_enabled`, `fetch_method`, `interval_minutes` を source 管理データに合わせて扱うよう更新
 - 進捗系ドキュメントを Phase 2 の主要機能実装後、Phase 3 着手前の状態に同期
 - `docs/current-status.md` の Open GitHub Issues を現行の open issue に更新
 - `docs/backlog-priority.md` の優先順位を現状の残課題と open issue に合わせて更新

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Phase 1 の記事閲覧フローに加えて、Phase 2 の主要機能、Phase 3
 現在地:
 
 - Phase 4 の Compose / CI / OpenAPI 整備まで実装済み
-- collector-service はまだ静的 source 設定依存
+- collector-service は article-service の source 管理 API から実行時に収集対象を同期
 - 検証状態の詳細は `docs/current-status.md` を参照
 
 ## Planned Repository Structure
@@ -86,4 +86,4 @@ Phase 1 の記事閲覧フローに加えて、Phase 2 の主要機能、Phase 3
 
 - 通常のコード変更では CI も `make verify` 相当を実行します
 - docs-only 変更では、GitHub Actions は required check を維持しつつ重い検証を省略します
-- collector-service の source 定義は現時点では Compose 上の静的設定です
+- collector-service は `ARTICLE_SERVICE_URL` 経由で source 一覧を取得し、`is_enabled=true` の source を収集します

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,21 +74,6 @@ services:
       ARTICLE_SERVICE_URL: ${ARTICLE_SERVICE_BASE_URL}
       AMQP_URL: ${RABBITMQ_URL}
       AMQP_EXCHANGE: tech-feed.events
-      COLLECTOR_SOURCES_JSON: |
-        [
-          {
-            "name": "Kubernetes Blog",
-            "type": "rss",
-            "url": "https://kubernetes.io/feed.xml",
-            "default_category": "kubernetes"
-          },
-          {
-            "name": "GitHub Changelog",
-            "type": "rss",
-            "url": "https://github.blog/changelog/feed/",
-            "default_category": "github"
-          }
-        ]
     ports:
       - "${COLLECTOR_SERVICE_PORT}:8082"
     depends_on:

--- a/docs/backlog-priority.md
+++ b/docs/backlog-priority.md
@@ -8,19 +8,18 @@
 
 ### Now
 
-1. collector-service の動的ソース同期
-2. `#7` kind デプロイ、Helm Chart、Argo CD の整備
-3. `#6` Proxmox クラスタ移行、永続化、監視拡張
+1. `#7` kind デプロイ、Helm Chart、Argo CD の整備
+2. `#6` Proxmox クラスタ移行、永続化、監視拡張
 
 ### Next
 
-4. 認証導入
-5. 監視基盤の詳細設計
+3. 認証導入
+4. 監視基盤の詳細設計
+5. collector の収集戦略拡張
 
 ### Later
 
 6. バックアップ / リストア運用の整理
-7. collector の収集戦略拡張
 
 ## Priority Rules
 

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -25,6 +25,7 @@
 - `api-gateway` の最小プロキシ
 - `api-gateway` 経由のソース管理 API 公開
 - `collector-service` の最小 RSS 収集フロー
+- `collector-service` の source 管理 API 連携と実行時同期
 - `frontend` の記事一覧 / 詳細 / 検索画面
 - `frontend` の記事検索結果 CSV ダウンロード
 - `frontend` のソース一覧 / 作成 / 編集 / 有効無効切り替え画面
@@ -49,10 +50,10 @@
 
 ## Highest Priority Next
 
-1. collector-service の動的ソース同期
-2. kind / Helm / Argo CD の整備
-3. Proxmox クラスタ移行、永続化、監視拡張
-4. 認証導入の設計整理
+1. kind / Helm / Argo CD の整備
+2. Proxmox クラスタ移行、永続化、監視拡張
+3. 認証導入の設計整理
+4. collector の収集戦略拡張
 
 ## Open GitHub Issues
 
@@ -61,7 +62,6 @@
 
 ## Known Gaps
 
-- ソース管理 UI/API とジョブ履歴 UI/API は実装済みだが、collector-service はまだ静的設定依存
 - 認証は未実装
 - kind / Helm / Argo CD は未着手
 

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -6,14 +6,6 @@
 
 ## Current Known Issues
 
-### Collector Source Configuration Is Still Static
-
-- 現在の collector-service は環境変数ベースのソース定義を使用している
-- ソース管理 API / UI はあるが、collector-service とはまだ接続されていない
-- アプリ上の source 作成・編集・有効無効切り替えは収集対象へ自動反映されない
-- 取得ジョブ履歴と失敗状況の可視化はできるが、収集対象自体の同期は未実装
-- Phase 2 の後続対応で collector 側連携が必要
-
 ### Authentication Is Not Implemented
 
 - api-gateway に JWT の導入ポイントはあるが、実装は未着手

--- a/frontend/src/ui/SourceManagementPage.tsx
+++ b/frontend/src/ui/SourceManagementPage.tsx
@@ -105,8 +105,8 @@ export function SourceManagementPage() {
           <p className="text-sm uppercase tracking-[0.35em] text-cyan-300">Phase 2</p>
           <h1 className="text-4xl font-semibold tracking-tight text-white">収集ソース管理</h1>
           <p className="max-w-3xl text-sm leading-6 text-slate-300">
-            ソース一覧、作成、編集、有効/無効切り替えを行います。現在の collector-service は静的設定のままなので、
-            ここでの変更は収集対象へはまだ自動反映されません。
+            ソース一覧、作成、編集、有効/無効切り替えを行います。collector-service はこの一覧を実行時に参照するため、
+            ここでの変更は次回収集から反映されます。
           </p>
         </div>
       </section>

--- a/services/article-service/internal/service/article_service.go
+++ b/services/article-service/internal/service/article_service.go
@@ -404,6 +404,7 @@ func (s *ArticleService) StartFetchJob(ctx context.Context, input StartFetchJobI
 			return StartFetchJobResult{}, newServiceError(ErrValidation, "source_id or source is required")
 		}
 
+		// 古い caller は source 本体しか送れないため、移行期間は article-service 側で source 解決を引き受ける。
 		var err error
 		sourceID, err = s.sourceRepo.EnsureSource(ctx, domain.Source{
 			Name:            input.Source.Name,

--- a/services/article-service/internal/service/article_service.go
+++ b/services/article-service/internal/service/article_service.go
@@ -377,7 +377,8 @@ func (s *ArticleService) Ingest(ctx context.Context, req IngestRequest) (IngestR
 }
 
 type StartFetchJobInput struct {
-	Source IngestSourceInput `json:"source"`
+	SourceID int64             `json:"source_id"`
+	Source   IngestSourceInput `json:"source"`
 }
 
 type StartFetchJobResult struct {
@@ -386,17 +387,35 @@ type StartFetchJobResult struct {
 }
 
 func (s *ArticleService) StartFetchJob(ctx context.Context, input StartFetchJobInput) (StartFetchJobResult, error) {
-	// collector は source 管理とまだ直結していないため、静的設定の source でも同じ入口で解決する。
-	sourceID, err := s.sourceRepo.EnsureSource(ctx, domain.Source{
-		Name:            input.Source.Name,
-		Type:            input.Source.Type,
-		FetchURL:        input.Source.FetchURL,
-		FetchMethod:     input.Source.FetchMethod,
-		IntervalMinutes: input.Source.IntervalMinutes,
-		DefaultCategory: input.Source.DefaultCategory,
-	})
-	if err != nil {
-		return StartFetchJobResult{}, err
+	var sourceID int64
+	if input.SourceID > 0 {
+		// source 一覧 API で解決済みの ID が来た場合は、それを job 作成にそのまま使う。
+		source, err := s.sourceRepo.GetByID(ctx, input.SourceID)
+		if err != nil {
+			return StartFetchJobResult{}, err
+		}
+		if source == nil {
+			return StartFetchJobResult{}, newServiceError(ErrNotFound, "source not found")
+		}
+		sourceID = source.ID
+	} else {
+		// 後方互換のため、source 情報だけの caller も引き続き受け付ける。
+		if strings.TrimSpace(input.Source.Name) == "" {
+			return StartFetchJobResult{}, newServiceError(ErrValidation, "source_id or source is required")
+		}
+
+		var err error
+		sourceID, err = s.sourceRepo.EnsureSource(ctx, domain.Source{
+			Name:            input.Source.Name,
+			Type:            input.Source.Type,
+			FetchURL:        input.Source.FetchURL,
+			FetchMethod:     input.Source.FetchMethod,
+			IntervalMinutes: input.Source.IntervalMinutes,
+			DefaultCategory: input.Source.DefaultCategory,
+		})
+		if err != nil {
+			return StartFetchJobResult{}, err
+		}
 	}
 
 	jobID, err := s.jobRepo.Create(ctx, sourceID)

--- a/services/article-service/internal/service/article_service_test.go
+++ b/services/article-service/internal/service/article_service_test.go
@@ -71,6 +71,7 @@ func (r *stubArticleRepo) BulkUpsert(ctx context.Context, sourceID int64, articl
 }
 
 type stubSourceRepo struct {
+	getByIDFunc           func(ctx context.Context, id int64) (*domain.Source, error)
 	ensureSourceFunc      func(ctx context.Context, source domain.Source) (int64, error)
 	updateFetchStatusFunc func(ctx context.Context, id int64, status string, errMsg *string) error
 }
@@ -79,7 +80,10 @@ func (r *stubSourceRepo) List(context.Context) ([]domain.Source, error) {
 	return nil, nil
 }
 
-func (r *stubSourceRepo) GetByID(context.Context, int64) (*domain.Source, error) {
+func (r *stubSourceRepo) GetByID(ctx context.Context, id int64) (*domain.Source, error) {
+	if r.getByIDFunc != nil {
+		return r.getByIDFunc(ctx, id)
+	}
 	return nil, nil
 }
 
@@ -165,6 +169,48 @@ func TestStartFetchJobEnsuresSourceAndCreatesJob(t *testing.T) {
 			DefaultCategory: "k8s",
 		},
 	})
+	if err != nil {
+		t.Fatalf("StartFetchJob returned error: %v", err)
+	}
+	if result.SourceID != 12 || result.JobID != 34 {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func TestStartFetchJobUsesExistingSourceID(t *testing.T) {
+	t.Parallel()
+
+	service := &ArticleService{
+		articleRepo: &stubArticleRepo{},
+		sourceRepo: &stubSourceRepo{
+			getByIDFunc: func(_ context.Context, id int64) (*domain.Source, error) {
+				if id != 12 {
+					t.Fatalf("unexpected source id lookup: %d", id)
+				}
+				return &domain.Source{ID: 12, Name: "Kubernetes"}, nil
+			},
+			ensureSourceFunc: func(context.Context, domain.Source) (int64, error) {
+				t.Fatal("EnsureSource should not be called when source_id is provided")
+				return 0, nil
+			},
+			updateFetchStatusFunc: func(context.Context, int64, string, *string) error { return nil },
+		},
+		jobRepo: &stubJobRepo{
+			createFunc: func(_ context.Context, sourceID int64) (int64, error) {
+				if sourceID != 12 {
+					t.Fatalf("unexpected source id: %d", sourceID)
+				}
+				return 34, nil
+			},
+			getByIDFunc: func(context.Context, int64) (*domain.FetchJob, error) { return nil, nil },
+			listFunc: func(context.Context, domain.ListFetchJobsParams) (domain.ListFetchJobsResult, error) {
+				return domain.ListFetchJobsResult{}, nil
+			},
+			finishFunc: func(context.Context, int64, string, int, int, int, *string) error { return nil },
+		},
+	}
+
+	result, err := service.StartFetchJob(context.Background(), StartFetchJobInput{SourceID: 12})
 	if err != nil {
 		t.Fatalf("StartFetchJob returned error: %v", err)
 	}

--- a/services/collector-service/internal/app/app.go
+++ b/services/collector-service/internal/app/app.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -22,17 +21,7 @@ func Run() error {
 		return fmt.Errorf("ARTICLE_SERVICE_URL is required")
 	}
 
-	rawSources := os.Getenv("COLLECTOR_SOURCES_JSON")
-	if rawSources == "" {
-		return fmt.Errorf("COLLECTOR_SOURCES_JSON is required")
-	}
-
-	var sources []collector.SourceConfig
-	if err := json.Unmarshal([]byte(rawSources), &sources); err != nil {
-		return fmt.Errorf("parse COLLECTOR_SOURCES_JSON: %w", err)
-	}
-
-	service := collector.NewService(articleServiceURL, sources)
+	service := collector.NewService(articleServiceURL)
 	if amqpURL := os.Getenv("AMQP_URL"); amqpURL != "" {
 		publisher, err := events.NewRabbitMQPublisher(amqpURL, getenv("AMQP_EXCHANGE", "tech-feed.events"))
 		if err != nil {

--- a/services/collector-service/internal/collector/service.go
+++ b/services/collector-service/internal/collector/service.go
@@ -147,6 +147,7 @@ func (s *Service) loadSources(ctx context.Context) ([]SourceConfig, error) {
 
 	sources := make([]SourceConfig, 0, len(payload.Items))
 	for _, source := range payload.Items {
+		// source の真実源は article-service に寄せ、collector 側では enabled なものだけを実行対象に絞る。
 		if !source.IsEnabled {
 			continue
 		}
@@ -157,6 +158,7 @@ func (s *Service) loadSources(ctx context.Context) ([]SourceConfig, error) {
 		source.FetchMethod = strings.TrimSpace(strings.ToLower(source.FetchMethod))
 		source.DefaultCategory = strings.TrimSpace(source.DefaultCategory)
 
+		// collector はまだ RSS 専用のため、未対応 source を黙って飛ばさず同期エラーとして止める。
 		switch {
 		case source.ID < 1:
 			return nil, fmt.Errorf("source sync returned source with invalid id: %d", source.ID)
@@ -377,6 +379,7 @@ func (s *Service) fetchRSS(ctx context.Context, source SourceConfig) ([]IngestAr
 	now := time.Now().UTC()
 	articles := make([]IngestArticle, 0, len(feed.Channel.Items))
 	for _, item := range feed.Channel.Items {
+		// source 側の default_category を collector で埋めておき、article-service には正規化済み記事だけを渡す。
 		article := IngestArticle{
 			Title:     strings.TrimSpace(item.Title),
 			URL:       strings.TrimSpace(item.Link),

--- a/services/collector-service/internal/collector/service.go
+++ b/services/collector-service/internal/collector/service.go
@@ -18,10 +18,14 @@ import (
 )
 
 type SourceConfig struct {
+	ID              int64  `json:"id"`
 	Name            string `json:"name"`
 	Type            string `json:"type"`
-	URL             string `json:"url"`
+	FetchURL        string `json:"fetch_url"`
+	FetchMethod     string `json:"fetch_method"`
+	IntervalMinutes int    `json:"interval_minutes"`
 	DefaultCategory string `json:"default_category"`
+	IsEnabled       bool   `json:"is_enabled"`
 }
 
 type rssFeed struct {
@@ -78,15 +82,13 @@ type RunResult struct {
 type Service struct {
 	client            *http.Client
 	articleServiceURL string
-	sources           []SourceConfig
 	publisher         events.EventPublisher
 }
 
-func NewService(articleServiceURL string, sources []SourceConfig) *Service {
+func NewService(articleServiceURL string) *Service {
 	return &Service{
 		client:            &http.Client{Timeout: 20 * time.Second},
 		articleServiceURL: articleServiceURL,
-		sources:           sources,
 		publisher:         events.NopPublisher{},
 	}
 }
@@ -100,8 +102,13 @@ func (s *Service) SetEventPublisher(publisher events.EventPublisher) {
 }
 
 func (s *Service) Run(ctx context.Context) ([]RunResult, error) {
-	results := make([]RunResult, 0, len(s.sources))
-	for _, source := range s.sources {
+	sources, err := s.loadSources(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]RunResult, 0, len(sources))
+	for _, source := range sources {
 		// source ごとに順に処理し、どの source で止まったかを呼び出し側から判断しやすくする。
 		result, err := s.collectSource(ctx, source)
 		if err != nil {
@@ -110,6 +117,67 @@ func (s *Service) Run(ctx context.Context) ([]RunResult, error) {
 		results = append(results, result)
 	}
 	return results, nil
+}
+
+type listSourcesResponse struct {
+	Items []SourceConfig `json:"items"`
+}
+
+func (s *Service) loadSources(ctx context.Context) ([]SourceConfig, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.articleServiceURL+"/api/v1/sources", nil)
+	if err != nil {
+		return nil, fmt.Errorf("create source sync request: %w", err)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("source sync request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		raw, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("source sync failed: status=%d body=%s", resp.StatusCode, string(raw))
+	}
+
+	var payload listSourcesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("decode source sync response: %w", err)
+	}
+
+	sources := make([]SourceConfig, 0, len(payload.Items))
+	for _, source := range payload.Items {
+		if !source.IsEnabled {
+			continue
+		}
+
+		source.Name = strings.TrimSpace(source.Name)
+		source.Type = strings.TrimSpace(strings.ToLower(source.Type))
+		source.FetchURL = strings.TrimSpace(source.FetchURL)
+		source.FetchMethod = strings.TrimSpace(strings.ToLower(source.FetchMethod))
+		source.DefaultCategory = strings.TrimSpace(source.DefaultCategory)
+
+		switch {
+		case source.ID < 1:
+			return nil, fmt.Errorf("source sync returned source with invalid id: %d", source.ID)
+		case source.Name == "":
+			return nil, fmt.Errorf("source sync returned source with empty name")
+		case source.Type != "rss":
+			return nil, fmt.Errorf("source %q has unsupported type: %s", source.Name, source.Type)
+		case source.FetchURL == "":
+			return nil, fmt.Errorf("source %q has empty fetch_url", source.Name)
+		case source.FetchMethod != "rss":
+			return nil, fmt.Errorf("source %q has unsupported fetch_method: %s", source.Name, source.FetchMethod)
+		case source.IntervalMinutes < 1:
+			return nil, fmt.Errorf("source %q has invalid interval_minutes: %d", source.Name, source.IntervalMinutes)
+		case source.DefaultCategory == "":
+			return nil, fmt.Errorf("source %q has empty default_category", source.Name)
+		}
+
+		sources = append(sources, source)
+	}
+
+	return sources, nil
 }
 
 func (s *Service) collectSource(ctx context.Context, source SourceConfig) (RunResult, error) {
@@ -127,14 +195,7 @@ func (s *Service) collectSource(ctx context.Context, source SourceConfig) (RunRe
 	payload := IngestPayload{
 		JobID:    started.JobID,
 		SourceID: started.SourceID,
-		Source: IngestSource{
-			Name:            source.Name,
-			Type:            source.Type,
-			FetchURL:        source.URL,
-			FetchMethod:     "rss",
-			IntervalMinutes: 60,
-			DefaultCategory: source.DefaultCategory,
-		},
+		Source:   toIngestSource(source),
 		Articles: items,
 	}
 
@@ -191,7 +252,8 @@ func (s *Service) collectSource(ctx context.Context, source SourceConfig) (RunRe
 }
 
 type startFetchJobPayload struct {
-	Source IngestSource `json:"source"`
+	SourceID int64        `json:"source_id,omitempty"`
+	Source   IngestSource `json:"source"`
 }
 
 type startFetchJobResult struct {
@@ -200,16 +262,10 @@ type startFetchJobResult struct {
 }
 
 func (s *Service) startFetchJob(ctx context.Context, source SourceConfig) (startFetchJobResult, error) {
-	// source 情報は start API にも渡し、article-service 側で source 解決と job 作成を一貫して行う。
+	// source 一覧 API で解決済みの ID を優先しつつ、source 情報も渡して downstream の shape を揃える。
 	payload := startFetchJobPayload{
-		Source: IngestSource{
-			Name:            source.Name,
-			Type:            source.Type,
-			FetchURL:        source.URL,
-			FetchMethod:     "rss",
-			IntervalMinutes: 60,
-			DefaultCategory: source.DefaultCategory,
-		},
+		SourceID: source.ID,
+		Source:   toIngestSource(source),
 	}
 
 	body, err := json.Marshal(payload)
@@ -297,7 +353,7 @@ func (s *Service) finishFetchJob(ctx context.Context, jobID int64, payload finis
 }
 
 func (s *Service) fetchRSS(ctx context.Context, source SourceConfig) ([]IngestArticle, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, source.URL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, source.FetchURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create rss request: %w", err)
 	}
@@ -341,6 +397,17 @@ func (s *Service) fetchRSS(ctx context.Context, source SourceConfig) ([]IngestAr
 	}
 
 	return articles, nil
+}
+
+func toIngestSource(source SourceConfig) IngestSource {
+	return IngestSource{
+		Name:            source.Name,
+		Type:            source.Type,
+		FetchURL:        source.FetchURL,
+		FetchMethod:     source.FetchMethod,
+		IntervalMinutes: source.IntervalMinutes,
+		DefaultCategory: source.DefaultCategory,
+	}
 }
 
 func parsePubDate(raw string) (time.Time, error) {

--- a/services/collector-service/internal/collector/service_http_test.go
+++ b/services/collector-service/internal/collector/service_http_test.go
@@ -48,22 +48,21 @@ func (p *stubEventPublisher) PublishFetchFailed(ctx context.Context, payload eve
 func TestRunCreatesAndFinishesFetchJobOnSuccess(t *testing.T) {
 	t.Parallel()
 
-	var startCalled bool
+	var startPayload startFetchJobPayload
 	var finishPayload finishFetchJobPayload
 	var ingestPayload IngestPayload
 
-	service := NewService("http://article-service", []SourceConfig{{
-		Name:            "Example",
-		Type:            "rss",
-		URL:             "http://feed-source/rss",
-		DefaultCategory: "cloud",
-	}})
+	service := NewService("http://article-service")
 	service.client = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		switch r.URL.Path {
+		case "/api/v1/sources":
+			return newJSONResponse(http.StatusOK, `{"items":[{"id":7,"name":"Example","type":"rss","fetch_url":"http://feed-source/rss","fetch_method":"rss","interval_minutes":30,"default_category":"cloud","is_enabled":true}]}`), nil
 		case "/rss":
 			return newXMLResponse(http.StatusOK, `<?xml version="1.0"?><rss><channel><item><title>Hello</title><link>https://example.com/1</link><description>desc</description><pubDate>Mon, 02 Jan 2006 15:04:05 +0900</pubDate></item></channel></rss>`), nil
 		case "/internal/fetch-jobs/start":
-			startCalled = true
+			if err := json.NewDecoder(r.Body).Decode(&startPayload); err != nil {
+				t.Fatalf("decode start payload: %v", err)
+			}
 			return newJSONResponse(http.StatusAccepted, `{"source_id":7,"job_id":11}`), nil
 		case "/internal/ingest":
 			if err := json.NewDecoder(r.Body).Decode(&ingestPayload); err != nil {
@@ -86,11 +85,14 @@ func TestRunCreatesAndFinishesFetchJobOnSuccess(t *testing.T) {
 		t.Fatalf("Run returned error: %v", err)
 	}
 
-	if !startCalled {
-		t.Fatal("expected start to be called")
+	if startPayload.SourceID != 7 || startPayload.Source.IntervalMinutes != 30 || startPayload.Source.FetchMethod != "rss" {
+		t.Fatalf("unexpected start payload: %+v", startPayload)
 	}
 	if ingestPayload.JobID != 11 || ingestPayload.SourceID != 7 {
 		t.Fatalf("unexpected ingest payload ids: %+v", ingestPayload)
+	}
+	if ingestPayload.Source.FetchURL != "http://feed-source/rss" || ingestPayload.Source.IntervalMinutes != 30 {
+		t.Fatalf("unexpected ingest source payload: %+v", ingestPayload.Source)
 	}
 	if finishPayload.Status != "success" || finishPayload.FetchedCount != 1 || finishPayload.InsertedCount != 1 || finishPayload.DuplicatedCount != 0 || finishPayload.ErrorMessage != nil {
 		t.Fatalf("unexpected finish payload: %+v", finishPayload)
@@ -100,25 +102,59 @@ func TestRunCreatesAndFinishesFetchJobOnSuccess(t *testing.T) {
 	}
 }
 
+func TestRunSkipsDisabledSources(t *testing.T) {
+	t.Parallel()
+
+	service := NewService("http://article-service")
+	service.client = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path != "/api/v1/sources" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		return newJSONResponse(http.StatusOK, `{"items":[{"id":7,"name":"Example","type":"rss","fetch_url":"http://feed-source/rss","fetch_method":"rss","interval_minutes":30,"default_category":"cloud","is_enabled":false}]}`), nil
+	})}
+
+	results, err := service.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected no results, got %+v", results)
+	}
+}
+
+func TestRunReturnsErrorWhenSourceSyncFails(t *testing.T) {
+	t.Parallel()
+
+	service := NewService("http://article-service")
+	service.client = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path != "/api/v1/sources" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		return newJSONResponse(http.StatusBadGateway, `{"error":"upstream down"}`), nil
+	})}
+
+	_, err := service.Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "source sync failed: status=502") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestRunFinishesFetchJobOnRSSFailure(t *testing.T) {
 	t.Parallel()
 
 	var finishPayload finishFetchJobPayload
 	var publishedPayload events.FetchFailedPayload
 
-	service := NewService("http://article-service", []SourceConfig{{
-		Name:            "Example",
-		Type:            "rss",
-		URL:             "http://feed-source/rss",
-		DefaultCategory: "cloud",
-	}})
+	service := NewService("http://article-service")
 	service.client = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
-		switch {
-		case r.URL.Path == "/rss":
+		switch r.URL.Path {
+		case "/api/v1/sources":
+			return newJSONResponse(http.StatusOK, `{"items":[{"id":7,"name":"Example","type":"rss","fetch_url":"http://feed-source/rss","fetch_method":"rss","interval_minutes":60,"default_category":"cloud","is_enabled":true}]}`), nil
+		case "/rss":
 			return newJSONResponse(http.StatusBadGateway, "boom\n"), nil
-		case r.URL.Path == "/internal/fetch-jobs/start":
+		case "/internal/fetch-jobs/start":
 			return newJSONResponse(http.StatusAccepted, `{"source_id":7,"job_id":11}`), nil
-		case r.URL.Path == "/internal/fetch-jobs/11/finish":
+		case "/internal/fetch-jobs/11/finish":
 			if err := json.NewDecoder(r.Body).Decode(&finishPayload); err != nil {
 				t.Fatalf("decode finish payload: %v", err)
 			}
@@ -150,19 +186,16 @@ func TestRunFinishesFetchJobOnRSSFailure(t *testing.T) {
 func TestRunIgnoresPublisherFailureOnRSSFailure(t *testing.T) {
 	t.Parallel()
 
-	service := NewService("http://article-service", []SourceConfig{{
-		Name:            "Example",
-		Type:            "rss",
-		URL:             "http://feed-source/rss",
-		DefaultCategory: "cloud",
-	}})
+	service := NewService("http://article-service")
 	service.client = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
-		switch {
-		case r.URL.Path == "/rss":
+		switch r.URL.Path {
+		case "/api/v1/sources":
+			return newJSONResponse(http.StatusOK, `{"items":[{"id":7,"name":"Example","type":"rss","fetch_url":"http://feed-source/rss","fetch_method":"rss","interval_minutes":60,"default_category":"cloud","is_enabled":true}]}`), nil
+		case "/rss":
 			return newJSONResponse(http.StatusBadGateway, "boom\n"), nil
-		case r.URL.Path == "/internal/fetch-jobs/start":
+		case "/internal/fetch-jobs/start":
 			return newJSONResponse(http.StatusAccepted, `{"source_id":7,"job_id":11}`), nil
-		case r.URL.Path == "/internal/fetch-jobs/11/finish":
+		case "/internal/fetch-jobs/11/finish":
 			return newJSONResponse(http.StatusNoContent, ``), nil
 		default:
 			t.Fatalf("unexpected path: %s", r.URL.Path)


### PR DESCRIPTION
## 概要

- collector-service が article-service の source 管理 API を実行時に参照して収集対象を同期するよう変更
- fetch job 開始時に `source_id` を受け渡し、既存 caller との後方互換も維持
- UI 文言、Compose 設定、進捗ドキュメントを新しい同期方式に合わせて更新

## 背景 / 目的

- source 管理 UI/API は実装済みだったが、collector-service は `COLLECTOR_SOURCES_JSON` による静的設定に依存していた
- source の作成、編集、有効無効の変更を次回収集から反映できる状態に揃える

## 変更内容

- collector-service で `/api/v1/sources` を読み込み、`is_enabled=true` かつ `rss` の source を収集対象に使用
- source 同期結果の `id`, `fetch_url`, `fetch_method`, `interval_minutes` を ingest / fetch job 開始 payload に反映
- article-service の fetch job 開始 API で `source_id` 指定を受け付け、未指定時は従来どおり source 情報から解決
- source 管理画面の説明文、Compose、README、current status などを実装後の状態に更新
- AGENT.md に PR 作成時の日本語・テンプレート確認ルールを明文化

## 影響範囲

- [x] frontend
- [ ] api-gateway
- [x] collector-service
- [x] article-service
- [ ] notification-service
- [ ] infra
- [x] docs

## 検証

- [x] `go test ./...`
- [x] `npm run build`
- [x] `docker compose config -q`
- [x] その他: `make verify`

## API / DB / Infra への影響

- [ ] API を変更した
- [ ] DB schema を変更した
- [x] Compose を変更した
- [ ] Kubernetes / Helm を変更した
- [ ] 大きな影響はない

## ドキュメント

- [ ] 必要に応じて `RULES.md` を更新した
- [x] 関連する `docs/` を更新した
- [ ] ドキュメント更新は不要

## リスク / 注意点

- collector-service は source 同期時に `rss` 以外の source をエラー扱いするため、将来 fetch method を拡張する場合は collector 側の対応も必要
- fetch job 開始 API は後方互換を維持しているが、source 管理 API を真実源として使う前提が強くなった

## 補足

- 今回の PR 更新で、題名と本文を既定テンプレート準拠の日本語に修正済み
