### PR TITLE
AGENT.md の責務説明を各実装領域へ分割する

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -49,82 +49,22 @@
 └── AGENT.md
 ```
 
-## Current Phase
+## Component-Specific Guidance
 
-現在は Phase 4 の Compose / CI / OpenAPI 整備まで実装済みです。
+トップレベルの `AGENT.md` は共通ルールと導線だけを扱います。
+各実装領域の責務や読み始めるべきファイルは、対象ディレクトリの `AGENT.md` を参照してください。
 
-Phase 1 で完了した範囲:
+- `frontend/AGENT.md`
+- `services/api-gateway/AGENT.md`
+- `services/article-service/AGENT.md`
+- `services/collector-service/AGENT.md`
+- `services/notification-service/AGENT.md`
 
-- article-service
-- collector-service の最小収集フロー
-- api-gateway
-- frontend
-- MySQL 接続
-- 記事一覧 / 詳細 / 検索
+現在の進捗、優先順位、フェーズ情報は次を参照します。
 
-Phase 2 で完了した範囲:
-
-- 既読 / お気に入り
-- ソース管理
-- CSV 出力
-- 取得ジョブ履歴
-
-Phase 3 で完了した範囲:
-
-- notification-service
-- RabbitMQ 連携
-- 新着通知と取得失敗通知
-
-Phase 4 で完了した範囲:
-
-- Docker Compose のローカル運用整備
-- GitHub Actions の最小 CI
-- OpenAPI の公開 API 追従
-
-現在の残課題:
-
-- kind / Helm / Argo CD の整備
-- Proxmox クラスタ移行、永続化、監視拡張
-
-次に優先して進める内容は以下です。
-
-- kind / Helm / Argo CD の整備
-- Proxmox クラスタ移行、永続化、監視拡張
-
-## Service Responsibilities
-
-### frontend
-
-- React + TypeScript + Vite
-- 記事一覧、詳細、検索 UI
-- API Gateway 経由でバックエンドアクセス
-
-### api-gateway
-
-- フロント向け単一入口
-- 将来の JWT 認証導入ポイント
-- 共通ログ、共通エラー制御
-- article-service へのプロキシ
-
-### article-service
-
-- 記事保存
-- 記事一覧 / 詳細 / 検索
-- collector-service からの内部取り込み API
-- ソース / 取得ジョブ履歴の基礎テーブル管理
-
-### collector-service
-
-- RSS 取得
-- 外部データ正規化
-- dedupe_key 生成
-- article-service への投入
-
-### notification-service
-
-- 通知一覧 / 既読更新 API
-- RabbitMQ 経由の新着通知 / 取得失敗通知
-- 後続フェーズで日次 / 週次ダイジェスト、Slack / メール連携を追加
+- `docs/current-status.md`
+- `docs/backlog-priority.md`
+- `docs/phases.md`
 
 ## Local Development
 
@@ -251,12 +191,3 @@ npm run build
 - 重要な利用者向け変更や運用上の変更は `CHANGELOG.md` を更新する
 - エージェント向けの入口説明や恒久ルールが変わった場合は `AGENT.md` や `RULES.md` も更新する
 - ドキュメント更新が不要と判断した場合でも、完了前に更新不要の理由を確認する
-
-## Where To Start Next
-
-次に着手する優先順は以下です。
-
-1. kind / Helm / Argo CD の整備に着手する
-2. Proxmox クラスタ移行、永続化、監視拡張を進める
-3. 認証導入の前提整理を進める
-4. collector の収集戦略拡張を進める

--- a/frontend/AGENT.md
+++ b/frontend/AGENT.md
@@ -1,0 +1,25 @@
+# AGENT.md
+
+## Responsibility
+
+`frontend` は React + TypeScript + Vite による UI 実装です。
+
+- 記事一覧、詳細、検索、通知、ソース管理の画面を提供する
+- バックエンド通信は `api-gateway` 経由で行う
+- 画面状態と検索条件の保持を担う
+
+## Read First
+
+作業内容に応じて次を起点に確認します。
+
+- `src/main.tsx`: エントリポイント
+- `src/lib/api.ts`: API Gateway との通信
+- `src/store/searchStore.ts`: 検索条件の状態管理
+- `src/ui/`: 画面コンポーネント群
+- `src/styles.css`: 全体スタイル
+
+## Implementation Notes
+
+- API 追加やレスポンス変更がある場合は `src/lib/api.ts` と対象画面を合わせて更新する
+- 検索や一覧の挙動を変える場合は `searchStore` の状態遷移を確認する
+- 画面追加時は既存の `src/ui/*Page.tsx` の粒度に揃える

--- a/services/api-gateway/AGENT.md
+++ b/services/api-gateway/AGENT.md
@@ -1,0 +1,23 @@
+# AGENT.md
+
+## Responsibility
+
+`api-gateway` はフロント向けの単一入口です。
+
+- 公開 API を受け、バックエンドサービスへ中継する
+- 共通のログ、エラー応答、CORS など HTTP 境界の責務を持つ
+- 将来の認証導入ポイントになる
+
+## Read First
+
+- `cmd/api-gateway/main.go`: 起動エントリポイント
+- `internal/app/app.go`: アプリ初期化
+- `internal/httpapi/routes.go`: ルーティング
+- `internal/httpapi/middleware.go`: 共通ミドルウェア
+- `internal/httpapi/routes_test.go`: ルートの期待仕様
+
+## Implementation Notes
+
+- 公開 API の追加や変更はまず `routes.go` を確認する
+- 横断的な HTTP 振る舞いは `middleware.go` に寄せる
+- サービス間 API を直接ここへ混在させず、公開境界として扱う

--- a/services/article-service/AGENT.md
+++ b/services/article-service/AGENT.md
@@ -1,0 +1,25 @@
+# AGENT.md
+
+## Responsibility
+
+`article-service` は記事管理の中核サービスです。
+
+- 記事一覧、詳細、検索を提供する
+- collector からの内部取り込みを受け付ける
+- ソース情報と取得ジョブ履歴の基礎データを管理する
+
+## Read First
+
+- `cmd/article-service/main.go`: 起動エントリポイント
+- `internal/app/app.go`: DI と初期化
+- `internal/httpapi/router.go`: HTTP ルート
+- `internal/service/article_service.go`: ユースケース
+- `internal/repository/`: 永続化
+- `internal/domain/models.go`: ドメインモデル
+- `internal/events/publisher.go`: イベント発行
+
+## Implementation Notes
+
+- API 変更は `router.go` と `article_service.go` を対で確認する
+- データ更新を伴う変更は repository と domain の整合を崩さない
+- 収集連携に影響する変更は collector 側の投入仕様も確認する

--- a/services/collector-service/AGENT.md
+++ b/services/collector-service/AGENT.md
@@ -1,0 +1,26 @@
+# AGENT.md
+
+## Responsibility
+
+`collector-service` は外部ソース収集と正規化を担当します。
+
+- RSS などの外部データを取得する
+- 記事データを正規化し `dedupe_key` を生成する
+- article-service へ取り込みを依頼する
+- 必要に応じてイベントを発行する
+
+## Read First
+
+- `cmd/collector-service/main.go`: 起動エントリポイント
+- `internal/app/app.go`: 設定と初期化
+- `internal/httpapi/routes.go`: 実行トリガーの HTTP 入口
+- `internal/collector/service.go`: 収集と正規化の本体
+- `internal/events/publisher.go`: イベント発行
+- `internal/collector/service_test.go`: 収集ロジックの期待仕様
+- `internal/collector/service_http_test.go`: HTTP 経由の期待仕様
+
+## Implementation Notes
+
+- 収集ロジック変更時は dedupe の安定性を崩さない
+- article-service への投入契約を変える場合は両サービスを同時に確認する
+- 外部入力の揺れは `internal/collector/service.go` で吸収する

--- a/services/notification-service/AGENT.md
+++ b/services/notification-service/AGENT.md
@@ -1,0 +1,26 @@
+# AGENT.md
+
+## Responsibility
+
+`notification-service` は通知の保存、配信契約、既読管理を担います。
+
+- 通知一覧と既読更新 API を提供する
+- RabbitMQ 経由の新着通知、取得失敗通知を取り込む
+- 将来のダイジェストや外部通知連携の拡張点になる
+
+## Read First
+
+- `cmd/notification-service/main.go`: 起動エントリポイント
+- `internal/app/app.go`: 初期化
+- `internal/httpapi/router.go`: HTTP ルート
+- `internal/service/notification_service.go`: ユースケース
+- `internal/repository/notification_repository.go`: 永続化
+- `internal/events/consumer.go`: イベント消費
+- `internal/events/contracts.go`: イベント契約
+- `internal/domain/models.go`: ドメインモデル
+
+## Implementation Notes
+
+- 通知 API の変更は `router.go` と `notification_service.go` を対で確認する
+- イベント形式を変える場合は `contracts.go` を起点に producer 側も合わせる
+- 既読更新や一覧取得の変更は repository のクエリ条件まで確認する


### PR DESCRIPTION
## 概要

- トップレベルの `AGENT.md` から `Current Phase` と service ごとの詳細責務説明を削除
- `frontend` と各 service 配下にローカル `AGENT.md` を追加し、必要な実装時だけ参照される構成へ変更

## 背景 / 目的

- ルートの `AGENT.md` が肥大化しており、実装と無関係な説明まで毎回読み込まれる状態だった
- 共通ルールはルートに残し、実装固有の責務説明は対象ディレクトリへ寄せて参照範囲を絞りたかった

## 変更内容

- ルート `AGENT.md` を共通ルールと導線中心の構成へ整理
- `frontend/AGENT.md` を追加
- `services/api-gateway/AGENT.md` を追加
- `services/article-service/AGENT.md` を追加
- `services/collector-service/AGENT.md` を追加
- `services/notification-service/AGENT.md` を追加

## 影響範囲

- [ ] frontend
- [ ] api-gateway
- [ ] collector-service
- [ ] article-service
- [ ] notification-service
- [ ] infra
- [x] docs

## 検証

- [ ] `go test ./...`
- [ ] `npm run build`
- [ ] `docker compose config -q`
- [x] その他: ドキュメント差分を確認

## API / DB / Infra への影響

- [ ] API を変更した
- [ ] DB schema を変更した
- [ ] Compose を変更した
- [ ] Kubernetes / Helm を変更した
- [x] 大きな影響はない

## ドキュメント

- [ ] 必要に応じて `RULES.md` を更新した
- [ ] 関連する `docs/` を更新した
- [ ] ドキュメント更新は不要

## リスク / 注意点

- ローカルワークツリーの変更は未コミットのまま残っています
- sandbox 制限のためローカル Git ブランチ作成とコミットは行っていません

## 補足

- GitHub 上では `docs/split-agent-guidance-20260416` ブランチに変更を反映しています