### PR TITLE
AGENT導線とプレイブックをトークン最適化向けに再編

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -2,57 +2,19 @@
 
 ## Purpose
 
-このリポジトリは、DevOps / インフラ / クラウド / SRE / CI/CD 関連の情報を定期収集し、一覧・検索・管理する学習用 Web アプリ `Tech Feed Hub` のモノレポです。
+このファイルは、このリポジトリで作業を始めるときの最短ルータです。
+最初から全ドキュメントを読まず、必要な範囲だけ開く前提で使います。
 
-目的は次の 2 点です。
+## Always Read
 
-- 技術情報を継続的に収集・閲覧できること
-- マイクロサービス、Kubernetes、GitOps、監視運用を段階的に学べること
+作業開始時は、まず次だけ確認します。
 
-生成 AI による要約や自動分類は初期スコープに含めません。
-
-## Source Of Truth
-
-要件の詳細は以下を優先して参照します。
-
-- `RULES.md`
-- `docs/requirements.md`
-- `docs/rules-operations.md`
-- `docs/dod.md`
-- `docs/test-policy.md`
-- `docs/release-migration-policy.md`
-- `docs/branch-strategy.md`
+- `AGENT.md`
 - `docs/current-status.md`
-- `docs/backlog-priority.md`
-- `docs/known-issues.md`
-- `docs/glossary.md`
-- `docs/architecture.md`
-- `docs/phases.md`
+- 対象領域の `AGENT.md`
+- `docs/agent-playbooks.md` の該当セクション
 
-## Repository Layout
-
-```text
-.
-├── frontend
-├── services
-│   ├── api-gateway
-│   ├── article-service
-│   ├── collector-service
-│   └── notification-service
-├── deployments
-│   ├── compose
-│   ├── docker
-│   └── k8s
-├── docs
-├── docker-compose.yml
-├── Makefile
-└── AGENT.md
-```
-
-## Component-Specific Guidance
-
-トップレベルの `AGENT.md` は共通ルールと導線だけを扱います。
-各実装領域の責務や読み始めるべきファイルは、対象ディレクトリの `AGENT.md` を参照してください。
+対象領域:
 
 - `frontend/AGENT.md`
 - `services/api-gateway/AGENT.md`
@@ -60,134 +22,47 @@
 - `services/collector-service/AGENT.md`
 - `services/notification-service/AGENT.md`
 
-現在の進捗、優先順位、フェーズ情報は次を参照します。
+## Read Only If Needed
 
-- `docs/current-status.md`
-- `docs/backlog-priority.md`
-- `docs/phases.md`
+- `RULES.md`: スコープ、責務、全体方針を変えるとき
+- `docs/backlog-priority.md`: 次に着手する Issue を選ぶとき
+- `docs/test-policy.md`: テスト追加判断に迷うとき
+- `docs/runbook.md`: 起動、切り分け、運用手順が必要なとき
+- `docs/branch-strategy.md`: branch、PR、merge の運用確認が必要なとき
+- `docs/api-guidelines.md`: 公開 API を変えるとき
+- `docs/db-guidelines.md`: DB や repository の責務を変えるとき
+- `docs/k8s-guidelines.md`: Helm、Argo CD、Kubernetes を変えるとき
+- `docs/requirements.md`: 要件やフェーズ適合を確認したいとき
 
-## Local Development
+## Quick Router
 
-### Requirements
+- UI 修正、表示崩れ、検索条件変更: `frontend/AGENT.md`
+- 公開 API 追加、gateway ルート変更: `services/api-gateway/AGENT.md`
+- 記事、ソース、fetch job の振る舞い変更: `services/article-service/AGENT.md`
+- 収集、正規化、ingest、dedupe 変更: `services/collector-service/AGENT.md`
+- 通知 API、既読、イベント消費変更: `services/notification-service/AGENT.md`
+- docs-only 変更: `docs/agent-playbooks.md` の `Docs-Only`
 
-- Docker
-- Docker Compose
-- Go 1.24+
-- Node.js 22+
-- npm
+## Non-Negotiables
 
-### First Setup
+- 変更に対応する docs は同じ変更内で更新する
+- PR の題名と本文は、日本語指定がない限り日本語で書く
+- PR 作成時は `.github/pull_request_template.md` を基準に本文を組み立てる
+- 明示的な指示がない限り `main` へ直接 push しない
+- 重要な方針変更は `RULES.md` 側も更新対象として確認する
 
-```bash
-cp .env.example .env
-docker compose config -q
-```
+## Verification Policy
 
-### Start All Services
+- まず対象領域の最小検証を実行する
+- 複数領域にまたがる変更、または最小検証で不安が残る変更では `make verify` を使う
+- docs-only 変更では重い検証を省略してよい
 
-```bash
-make up
-```
+## Documentation Router
 
-### Stop
-
-```bash
-make down
-```
-
-volume も含めて初期化したい場合:
-
-```bash
-make reset
-```
-
-## Verification
-
-Go サービス確認:
-
-```bash
-GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...
-```
-
-frontend 確認:
-
-```bash
-cd frontend
-npm install
-npm run build
-```
-
-## Implementation Rules
-
-- 過剰設計より、学習しやすさと継続運用しやすさを優先する
-- ただしサービス責務は明確に分離する
-- 初期は共有 MySQL を許容するが、コード上は各サービスが自分の責務データのみを扱う
-- Docker Compose で全体起動できることを優先する
-- kind / 実クラスタへ移しやすいよう、設定は環境変数で切り替える
-- OpenAPI を前提に API を追加する
-- 破壊的変更を入れる場合は、Compose 起動と既存 API の継続性を確認する
-- 処理意図がコードだけでは追いにくい箇所には、明示的な指示がなくても日本語コメントを付ける
-- コメントは要点だけを短く書き、コードの逐語説明ではなく判断理由や前提を残す
-
-## API Design Rules
-
-- 公開 API は基本的に `api-gateway` 配下に置く
-- サービス間通信用エンドポイントは `internal` プレフィックスで分離する
-- 検索、フィルタ、ソート、ページネーションを早い段階で意識する
-- CSV 出力は将来 `api-gateway` 側で制御する
-
-## Data Rules
-
-- 記事重複防止には `dedupe_key` を使う
-- 日時は UTC ベースで保存する
-- タグは初期実装では JSON 配列で保持する
-- DB スキーマ変更時は `deployments/compose/mysql/init` と今後のマイグレーション方針の整合を意識する
-
-## Deployment Direction
-
-- 開発初期は Docker Compose
-- Kubernetes 検証は kind
-- その後 Proxmox 上の実クラスタに移行
-- GitOps は Helm + Argo CD を想定
-
-以下は環境差分が出やすいため分離を意識すること。
-
-- Ingress
-- StorageClass
-- Domain
-- Secret 管理
-
-## Monitoring Direction
-
-初期は最小構成です。
-
-- health check
-- 構造化ログの導入余地
-- 将来的に Prometheus / Grafana / Loki を追加
-
-## GitHub Preparation Notes
-
-- `.env` はコミットしない
-- `.env.example` を最新に保つ
-- `node_modules`, `dist`, `*.tsbuildinfo` はコミットしない
-- ドキュメント更新を伴う設計変更では `docs/` も更新する
-- Git のコミットメッセージは日本語で記述する
-- Pull Request の題名と本文は、明示的な指示がない限り日本語で記述する
-- Pull Request 作成時は `.github/pull_request_template.md` を使い、各項目を実施内容に合わせて埋める
-- Pull Request 作成前に `.github/pull_request_template.md` を必ず開いて内容を確認する
-- GitHub API / MCP で Pull Request を作成する場合、テンプレートは自動適用されない前提で扱い、テンプレートを元にした本文を自分で組み立てて渡す
-- Pull Request 作成直後に、題名が日本語であることと、本文がテンプレートの主要項目を満たしていることを確認し、不足があればその場で更新する
-
-## Documentation Update Rules
-
-- エージェントは作業内容に応じて、必要なドキュメント更新を自分で判断して同じ変更内で実施する
-- 実装、設計、手順、現在地、優先順位、既知課題のいずれかが変わった場合、コード変更だけで完了扱いにしない
-- API 変更時は OpenAPI と API 関連 docs を確認し、必要なら更新する
-- DB 変更時は schema / init SQL / migration と DB 関連 docs を確認し、必要なら更新する
-- 手順変更時は `README.md` または `docs/runbook.md` を更新する
-- フェーズ進行、完了状態、次にやることが変わった場合は `docs/current-status.md` を更新する
-- 優先順位が変わった場合は `docs/backlog-priority.md` を更新する
-- 新しい制約や未解決事項が増えた場合は `docs/known-issues.md` を更新する
-- 重要な利用者向け変更や運用上の変更は `CHANGELOG.md` を更新する
-- エージェント向けの入口説明や恒久ルールが変わった場合は `AGENT.md` や `RULES.md` も更新する
-- ドキュメント更新が不要と判断した場合でも、完了前に更新不要の理由を確認する
+- 現在地、完了状況、次優先が変わる: `docs/current-status.md`
+- 優先順位が変わる: `docs/backlog-priority.md`
+- API 契約が変わる: `docs/openapi/api-gateway.yaml` と API 関連 docs
+- DB / schema / migration 方針が変わる: DB 関連 docs
+- 起動や運用手順が変わる: `README.md` または `docs/runbook.md`
+- 恒久ルールが変わる: `RULES.md`
+- エージェントの入口や最小読込導線が変わる: `AGENT.md` または `docs/agent-playbooks.md`

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Phase 1 の記事閲覧フローに加えて、Phase 2 の主要機能、Phase 3
 ## Rule Documents
 
 - `AGENT.md`: 開発者向けの入口
+- `docs/agent-playbooks.md`: エージェント向けの最小読込プレイブック
 - `RULES.md`: プロジェクト全体ルール
 - `docs/requirements.md`: 要件整理
 - `docs/rules-operations.md`: ルール運用方法

--- a/docs/agent-playbooks.md
+++ b/docs/agent-playbooks.md
@@ -1,0 +1,200 @@
+# Agent Playbooks
+
+## Purpose
+
+このドキュメントは、よくある作業ごとに最小読込セットを固定するためのものです。
+作業開始時は、必要なセクションだけ読みます。
+
+## Common Rule
+
+どの作業でも最初に確認するもの:
+
+- `AGENT.md`
+- `docs/current-status.md`
+- 対象領域の `AGENT.md`
+
+必要になってから開くもの:
+
+- `RULES.md`
+- 領域別 guideline
+- `docs/runbook.md`
+- `docs/test-policy.md`
+
+## Docs-Only
+
+### Read
+
+- `AGENT.md`
+- 更新対象の docs
+
+### Usually Skip
+
+- 実装コード
+- 重い検証手順
+
+### Verification
+
+- リンク先、コマンド、ファイル名の整合だけ確認する
+
+## Frontend UI Change
+
+### Read
+
+- `frontend/AGENT.md`
+- 対象画面
+- `frontend/src/lib/api.ts`
+
+### Read If Needed
+
+- `frontend/src/store/searchStore.ts`
+- `services/api-gateway/AGENT.md`
+- `docs/openapi/api-gateway.yaml`
+
+### Verification
+
+- `cd frontend && npm run build`
+
+## Public API Change
+
+### Read
+
+- `services/api-gateway/AGENT.md`
+- 対象 upstream service の `AGENT.md`
+- `docs/openapi/api-gateway.yaml`
+- `docs/api-guidelines.md`
+
+### Read If Needed
+
+- `frontend/AGENT.md`
+- `RULES.md`
+
+### Verification
+
+- 対象 Go service の `go test ./...`
+- 影響が複数領域に跨るなら `make verify`
+
+## Article-Service Change
+
+### Read
+
+- `services/article-service/AGENT.md`
+- 対象 `service` / `repository` / `router`
+
+### Read If Needed
+
+- `docs/db-guidelines.md`
+- `docs/test-policy.md`
+- `services/collector-service/AGENT.md`
+- `services/notification-service/AGENT.md`
+
+### Verification
+
+- `cd services/article-service && GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...`
+
+## Collector Change
+
+### Read
+
+- `services/collector-service/AGENT.md`
+- 対象 `service.go` とテスト
+
+### Read If Needed
+
+- `services/article-service/AGENT.md`
+- `docs/test-policy.md`
+- `docs/runbook.md`
+
+### Verification
+
+- `cd services/collector-service && GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...`
+
+## Notification Change
+
+### Read
+
+- `services/notification-service/AGENT.md`
+- 対象 `service` / `repository` / `events`
+
+### Read If Needed
+
+- producer 側 service の `AGENT.md`
+- `docs/test-policy.md`
+- `docs/runbook.md`
+
+### Verification
+
+- `cd services/notification-service && GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...`
+
+## DB / Repository Change
+
+### Read
+
+- 対象 service の `AGENT.md`
+- `docs/db-guidelines.md`
+- `deployments/compose/mysql/init/001_schema.sql`
+
+### Read If Needed
+
+- `RULES.md`
+- `docs/release-migration-policy.md`
+
+### Verification
+
+- 対象 service の `go test ./...`
+- 変更が広い場合は `make verify`
+
+## Compose / CI / Infra Change
+
+### Read
+
+- `AGENT.md`
+- `docs/runbook.md`
+- `docs/test-policy.md`
+
+### Read If Needed
+
+- `docs/k8s-guidelines.md`
+- `docs/branch-strategy.md`
+- `RULES.md`
+
+### Verification
+
+- 対象コマンド
+- 迷う場合は `make verify`
+
+## Rule / Policy Change
+
+### Read
+
+- `RULES.md`
+- `docs/rules-operations.md`
+- `AGENT.md`
+
+### Read If Needed
+
+- `docs/requirements.md`
+- `docs/dod.md`
+- `docs/branch-strategy.md`
+
+### Verification
+
+- 変更された方針が矛盾なく参照できるかを確認する
+
+## Bugfix Triage
+
+### Read
+
+- 発生箇所の `AGENT.md`
+- 失敗しているコード
+- 直近で関連するテスト
+
+### Read If Needed
+
+- `docs/runbook.md`
+- `docs/known-issues.md`
+- `docs/test-policy.md`
+
+### Verification
+
+- 再現に近い最小テスト
+- 必要なら回帰テストを追加

--- a/docs/rules-operations.md
+++ b/docs/rules-operations.md
@@ -2,12 +2,14 @@
 
 ## Purpose
 
-このドキュメントは、このリポジトリで定義したルール群をどう運用するかをまとめたものです。
+このドキュメントは、ルール群をどの順で、どの粒度で使うかを固定するためのものです。
+トークン効率のため、常に全件読まず、必要な文書だけ開きます。
 
-対象:
+## Managed Documents
 
 - `RULES.md`
 - `AGENT.md`
+- `docs/agent-playbooks.md`
 - `docs/requirements.md`
 - `docs/api-guidelines.md`
 - `docs/db-guidelines.md`
@@ -28,264 +30,138 @@
 
 ## Source Of Truth
 
-ルール参照の優先順位は以下です。
+優先順位は次の通りです。
 
 1. `RULES.md`
 2. `docs/requirements.md`
-3. `docs/api-guidelines.md`
-4. `docs/db-guidelines.md`
-5. `docs/k8s-guidelines.md`
-6. `docs/dod.md`
-7. `docs/test-policy.md`
-8. `docs/release-migration-policy.md`
-9. `docs/architecture.md`
-10. `docs/phases.md`
-11. `AGENT.md`
+3. 領域別 guideline
+4. `docs/dod.md`
+5. `docs/test-policy.md`
+6. `docs/release-migration-policy.md`
+7. `docs/architecture.md`
+8. `docs/phases.md`
+9. `AGENT.md`
+10. `docs/agent-playbooks.md`
+11. `docs/current-status.md`
 
 補足:
 
-- `RULES.md` は最上位の運用ルール
-- `docs/requirements.md` は要件の基準
-- 各 guideline は領域ごとの実装判断基準
-- `docs/dod.md` は完了判断基準
-- `docs/runbook.md` は日常運用と切り分け手順
-- `docs/test-policy.md` はテスト追加判断基準
-- `docs/naming-conventions.md` は命名の基準
-- `docs/release-migration-policy.md` は変更の安全な進め方
-- `docs/branch-strategy.md` は Git 運用の基準
-- `docs/adr/*` は設計判断の理由
-- `docs/current-status.md` は次セッションの入口
-- `docs/backlog-priority.md` は優先順の固定
-- `docs/known-issues.md` は既知制約の固定
-- `docs/glossary.md` は用語の固定
-- `CHANGELOG.md` は重要変更の要約
-- `AGENT.md` は開発者向けの入口
+- `RULES.md` は全体方針
+- `AGENT.md` は入口
+- `docs/agent-playbooks.md` は最小読込の実務手順
+- `docs/current-status.md` は次セッションの現在地
+
+## Start Rules
+
+### Always Read
+
+作業開始時は次だけ確認する。
+
+- `AGENT.md`
+- `docs/current-status.md`
+- 対象領域の `AGENT.md`
+- `docs/agent-playbooks.md` の該当セクション
+
+### Read On Demand
+
+以下は必要になった時だけ開く。
+
+- `RULES.md`: スコープ、責務、全体方針を変える時
+- `docs/backlog-priority.md`: 次の Issue を選ぶ時
+- `docs/branch-strategy.md`: branch / PR / merge 運用を確認する時
+- `docs/test-policy.md`: テスト追加判断に迷う時
+- `docs/runbook.md`: 起動、障害切り分け、運用手順が必要な時
+- `docs/api-guidelines.md`: 公開 API を変える時
+- `docs/db-guidelines.md`: DB、repository、migration を変える時
+- `docs/k8s-guidelines.md`: Kubernetes、Helm、Argo CD を変える時
+- `docs/requirements.md`: 要件適合に不安がある時
 
 ## How To Use
 
-### When Starting Work
-
-作業開始時は最低限、以下を確認する。
-
-- `AGENT.md`
-- `RULES.md`
-- `docs/current-status.md`
-- `docs/backlog-priority.md`
-- `docs/branch-strategy.md`
-- 今回の変更に関係する guideline
-
-例:
-
-- API 変更なら `docs/api-guidelines.md`
-- DB 変更なら `docs/db-guidelines.md`
-- Kubernetes / Helm 変更なら `docs/k8s-guidelines.md`
-
 ### When Designing
 
-- まず要件が `docs/requirements.md` に反していないか確認する
-- 責務境界が `RULES.md` の方針を壊していないか確認する
-- フェーズ外の機能を入れようとしていないか確認する
+- 変更が `RULES.md` と `docs/requirements.md` に反していないか確認する
+- プレイブックで十分に読める範囲を超える時だけ追加 docs を開く
+- 重要な設計判断は ADR 化対象か確認する
 
 ### When Implementing
 
-- API を追加したら OpenAPI 更新対象か確認する
-- DB スキーマを変えたら migration / init SQL / ドキュメントの整合を確認する
-- Kubernetes 関連を変えたら Helm values で環境差分吸収できるか確認する
-- 重要な設計判断は ADR 化対象か確認する
-- 既知制約なら `docs/known-issues.md` 更新対象か確認する
-- 重要変更なら `CHANGELOG.md` 更新対象か確認する
-- 処理意図が読み取りにくい実装には、明示指示がなくても日本語コメントを補う
-- コメントは「なぜそうしているか」を優先し、逐語説明や一時メモは残さない
+- API 変更時は OpenAPI 更新対象か確認する
+- DB 変更時は init SQL / migration / repository 整合を確認する
+- docs 更新対象を同じ変更内で処理する
+- 処理意図が追いにくい箇所には日本語コメントを補う
 
 ### When Reviewing
 
-レビュー時は以下を確認する。
-
 - ルール違反がないか
-- 責務分離が崩れていないか
-- 初期スコープ外の複雑化が入っていないか
+- プレイブックに反して不要な横断変更が入っていないか
 - ドキュメント更新漏れがないか
 - `docs/dod.md` を満たしているか
-- PR の題名と本文が、明示的な指示なしで英語になっていないか
-- 変更箇所のうち意図が追いにくい部分に、日本語コメントが不足していないか
-
-### CI Interpretation
-
-- 通常のコード変更では `make verify` を回す
-- docs-only 変更では、required status check を壊さない範囲で重い検証を省略してよい
-- その場合でも `verify` チェック自体は成功状態を返す
-- docs-only 判定ロジックは `.github/workflows/ci.yml` を正本とする
-
-## Update Policy
-
-### RULES.md を更新する場合
-
-以下のような変更時に更新する。
-
-- プロジェクト全体方針の変更
-- 初期スコープ / 非スコープの変更
-- サービス責務の変更
-- フェーズ順序の変更
-- 運用方針の変更
-
-### requirements.md を更新する場合
-
-以下のような変更時に更新する。
-
-- 要件追加 / 削除
-- 対象ソースの追加
-- 非機能要件や学習要件の変更
-- 技術スタック方針の変更
-
-### api-guidelines.md を更新する場合
-
-以下のような変更時に更新する。
-
-- API 命名規則の変更
-- エラーレスポンス方針の変更
-- CSV API 方針の変更
-- 認証 / versioning 方針の変更
-
-### db-guidelines.md を更新する場合
-
-以下のような変更時に更新する。
-
-- テーブル責務変更
-- migration 方針変更
-- ORM / sqlc 方針変更
-- index / 検索方針変更
-
-### k8s-guidelines.md を更新する場合
-
-以下のような変更時に更新する。
-
-- Helm / Argo CD 方針変更
-- Ingress / Secret / PVC 方針変更
-- kind から実クラスタ移行戦略変更
-- リソース配分方針変更
-
-### dod.md を更新する場合
-
-以下のような変更時に更新する。
-
-- 完了条件の見直し
-- PR で毎回確認すべき事項の変更
-
-### runbook.md を更新する場合
-
-以下のような変更時に更新する。
-
-- 起動手順の変更
-- 障害切り分け手順の変更
-- 日常運用手順の追加
-
-### test-policy.md を更新する場合
-
-以下のような変更時に更新する。
-
-- テスト粒度や優先順位の変更
-- CI 対象の変更
-
-### naming-conventions.md を更新する場合
-
-以下のような変更時に更新する。
-
-- API / DB / code の命名方針変更
-- branch / commit 命名方針変更
-
-### release-migration-policy.md を更新する場合
-
-以下のような変更時に更新する。
-
-- 破壊的変更の扱い変更
-- リリース / 移行の進め方変更
-
-### branch-strategy.md を更新する場合
-
-以下のような変更時に更新する。
-
-- main 運用ルール変更
-- PR 必須ルール変更
-- merge 方式変更
-- branch 種別変更
-- branch 削除ルール変更
-
-### ADR を追加する場合
-
-以下のような変更時に追加する。
-
-- 重要な設計採用判断
-- 将来の実装方針へ長く影響する決定
-- 単純な実装差分ではなく、判断理由を残す価値が高い変更
-
-### current-status.md を更新する場合
-
-以下のような変更時に更新する。
-
-- 主要機能が完了した
-- 現在フェーズが変わった
-- 次にやるべき優先事項が変わった
-
-### backlog-priority.md を更新する場合
-
-以下のような変更時に更新する。
-
-- 優先順位を入れ替えた
-- 新しい高優先度 Issue を追加した
-
-### known-issues.md を更新する場合
-
-以下のような変更時に更新する。
-
-- 既知の制約や不具合を見つけた
-- 既知課題が解消された
-
-### glossary.md を更新する場合
-
-以下のような変更時に更新する。
-
-- 用語の意味がぶれそうな概念を追加した
-- 新しい内部概念や運用用語が増えた
-
-### CHANGELOG.md を更新する場合
-
-以下のような変更時に更新する。
-
-- 重要な機能追加
-- 重要な方針変更
-- 次セッションで把握すべき大きな変更
 
 ## Change Checklist
 
-変更内容ごとに、最低限以下を揃える。
-
-### API 変更
+### API Change
 
 - 実装
 - OpenAPI
 - `docs/api-guidelines.md` との整合確認
 - frontend 影響確認
 
-### DB 変更
+### DB Change
 
 - スキーマ変更
 - 初期 SQL または migration 更新
 - repository / service 更新
 - `docs/db-guidelines.md` との整合確認
 
-### Kubernetes / Helm 変更
+### Kubernetes / Helm Change
 
 - manifest / chart / values 更新
 - kind と実クラスタ差分の確認
 - `docs/k8s-guidelines.md` との整合確認
 
-### プロジェクト方針変更
+### Project Policy Change
 
 - `RULES.md` 更新
-- `docs/requirements.md` 更新
-- 必要なら `AGENT.md` 更新
-- 必要なら ADR 追加
-- 必要なら `CHANGELOG.md` 更新
+- 必要に応じて `docs/requirements.md` 更新
+- 必要に応じて `AGENT.md` 更新
+- エージェントの読込導線が変わるなら `docs/agent-playbooks.md` 更新
+- 必要に応じて ADR または `CHANGELOG.md` 更新
+
+## Update Policy
+
+### Update `RULES.md` When
+
+- プロジェクト全体方針が変わる
+- 初期スコープや非スコープが変わる
+- サービス責務やフェーズ順が変わる
+
+### Update `AGENT.md` When
+
+- 最初に読むべき導線が変わる
+- 非交渉ルールを入口に残す必要が変わる
+
+### Update `docs/agent-playbooks.md` When
+
+- よくある作業の最小読込セットが変わる
+- 新しい定番作業を追加したい
+- 無駄な横断読込を減らしたい
+
+### Update `docs/current-status.md` When
+
+- 主要機能が完了した
+- 現在フェーズが変わった
+- 次優先が変わった
+
+### Update `docs/backlog-priority.md` When
+
+- 優先順位を入れ替えた
+- 新しい高優先タスクを追加した
+
+### Update `docs/known-issues.md` When
+
+- 既知の制約や不具合を見つけた
+- 既知課題が解消された
 
 ## GitHub Workflow Usage
 
@@ -295,67 +171,37 @@
 - 機能追加は `feature_request.md`
 - 実装タスクは `task.md`
 
-Issue 作成時は、ルールや要件に関係する背景を記載する。
-
 ### Pull Request
 
-- PR では `.github/pull_request_template.md` を使う
+- `.github/pull_request_template.md` を使う
 - `Scope`
 - `Verification`
 - `API / DB / Infra Impact`
 - `Documentation`
-  を最低限埋める
 
 ## Decision Rules
 
-判断に迷った場合は次の順で決める。
+迷った時は次の順で判断する。
 
 1. `RULES.md` に反していないか
 2. 初期スコープに収まっているか
-3. Docker Compose で扱いやすいか
+3. Compose で扱いやすいか
 4. kind / Helm / Argo CD へ持っていきやすいか
-5. ミニ PC 32GB で無理がないか
-6. 学習効果が高いか
+5. 学習効果が高いか
 
 ## Anti-Patterns
 
-- ルールを更新せずに設計だけ変えること
-- guideline を読まずに領域横断変更を進めること
-- 初期スコープ外の複雑機能を黙って入れること
-- Compose 前提を壊す変更を無言で入れること
-- kind 専用実装を本番設計に埋め込むこと
+- 毎回フルドキュメント読込から始めること
+- 領域外のコードや docs を無差別に開くこと
+- ルール変更を docs に反映しないこと
 - 重要な判断理由を ADR に残さないこと
-- 現在地が変わったのに `docs/current-status.md` を放置すること
-- 既知課題を Issue や口頭だけに残して `docs/known-issues.md` に書かないこと
+- 現在地が変わったのに `docs/current-status.md` を更新しないこと
 
-## Practical Workflow
+## Session Continuity
 
-推奨運用手順:
-
-1. Issue を作る
-2. branch を切る
-3. 影響範囲を確認する
-4. 対応する rule / guideline を読む
-5. 実装する
-6. 必要な docs を更新する
-7. `make verify` を実行する
-8. PR を作る
-
-## Session Continuity Rules
-
-新規セッションでも品質を維持するために、次を運用する。
-
-- セッション開始時に `docs/current-status.md` を確認する
+- セッション開始時は `docs/current-status.md` を確認する
+- 作業ごとに `docs/agent-playbooks.md` の該当セクションを使う
 - 優先順位判断は `docs/backlog-priority.md` を使う
 - 既知制約は `docs/known-issues.md` を確認する
-- 用語の意味は `docs/glossary.md` を確認する
-- 大きな変更は `CHANGELOG.md` に残す
 - 標準検証は `make verify` を使う
-- コミットメッセージ規約は `docs/naming-conventions.md` を参照し、日本語で記述する
 - Git 運用は `docs/branch-strategy.md` を参照する
-- docs-only 変更時の CI 軽量化ルールは `.github/workflows/ci.yml` と `docs/test-policy.md` を参照する
-
-## Notes
-
-- ルールは実装を止めるためではなく、判断を揃えるために使う
-- ルールが現実に合わなくなったら、実装側で黙って逸脱せず、ルール側を更新する

--- a/frontend/AGENT.md
+++ b/frontend/AGENT.md
@@ -1,25 +1,24 @@
 # AGENT.md
 
-## Responsibility
+## Read When
 
-`frontend` は React + TypeScript + Vite による UI 実装です。
+- 画面表示、UI 文言、スタイル、フォーム、検索条件を変えるとき
+- gateway のレスポンス変更に frontend が追従するとき
 
-- 記事一覧、詳細、検索、通知、ソース管理の画面を提供する
-- バックエンド通信は `api-gateway` 経由で行う
-- 画面状態と検索条件の保持を担う
+## Open First
 
-## Read First
-
-作業内容に応じて次を起点に確認します。
-
-- `src/main.tsx`: エントリポイント
-- `src/lib/api.ts`: API Gateway との通信
-- `src/store/searchStore.ts`: 検索条件の状態管理
-- `src/ui/`: 画面コンポーネント群
+- `src/ui/`: 対象画面
+- `src/lib/api.ts`: API 呼び出し
+- `src/store/searchStore.ts`: 検索条件と一覧状態
 - `src/styles.css`: 全体スタイル
 
-## Implementation Notes
+## Usually Skip
 
-- API 追加やレスポンス変更がある場合は `src/lib/api.ts` と対象画面を合わせて更新する
-- 検索や一覧の挙動を変える場合は `searchStore` の状態遷移を確認する
-- 画面追加時は既存の `src/ui/*Page.tsx` の粒度に揃える
+- backend の詳細実装
+- infra / k8s docs
+
+ただし API 契約変更時は `api-gateway` 側を確認します。
+
+## Minimum Verification
+
+- `cd frontend && npm run build`

--- a/services/api-gateway/AGENT.md
+++ b/services/api-gateway/AGENT.md
@@ -1,23 +1,24 @@
 # AGENT.md
 
-## Responsibility
+## Read When
 
-`api-gateway` はフロント向けの単一入口です。
+- 公開 API を追加、変更、削除するとき
+- proxy、CORS、共通エラー、HTTP ミドルウェアを触るとき
 
-- 公開 API を受け、バックエンドサービスへ中継する
-- 共通のログ、エラー応答、CORS など HTTP 境界の責務を持つ
-- 将来の認証導入ポイントになる
+## Open First
 
-## Read First
+- `internal/httpapi/routes.go`
+- `internal/httpapi/middleware.go`
+- `internal/httpapi/routes_test.go`
+- `internal/app/app.go`
 
-- `cmd/api-gateway/main.go`: 起動エントリポイント
-- `internal/app/app.go`: アプリ初期化
-- `internal/httpapi/routes.go`: ルーティング
-- `internal/httpapi/middleware.go`: 共通ミドルウェア
-- `internal/httpapi/routes_test.go`: ルートの期待仕様
+## Usually Skip
 
-## Implementation Notes
+- frontend の表示実装
+- collector / notification の内部詳細
 
-- 公開 API の追加や変更はまず `routes.go` を確認する
-- 横断的な HTTP 振る舞いは `middleware.go` に寄せる
-- サービス間 API を直接ここへ混在させず、公開境界として扱う
+ただし upstream 契約を変える場合は対象サービスの `AGENT.md` も開きます。
+
+## Minimum Verification
+
+- `cd services/api-gateway && GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...`

--- a/services/article-service/AGENT.md
+++ b/services/article-service/AGENT.md
@@ -1,25 +1,25 @@
 # AGENT.md
 
-## Responsibility
+## Read When
 
-`article-service` は記事管理の中核サービスです。
+- 記事、ソース、fetch job の振る舞いを変えるとき
+- ingest、検索、CSV 前提データ、永続化条件を変えるとき
 
-- 記事一覧、詳細、検索を提供する
-- collector からの内部取り込みを受け付ける
-- ソース情報と取得ジョブ履歴の基礎データを管理する
+## Open First
 
-## Read First
+- `internal/httpapi/router.go`
+- `internal/service/article_service.go`
+- `internal/repository/`
+- `internal/domain/models.go`
+- `internal/events/publisher.go`
 
-- `cmd/article-service/main.go`: 起動エントリポイント
-- `internal/app/app.go`: DI と初期化
-- `internal/httpapi/router.go`: HTTP ルート
-- `internal/service/article_service.go`: ユースケース
-- `internal/repository/`: 永続化
-- `internal/domain/models.go`: ドメインモデル
-- `internal/events/publisher.go`: イベント発行
+## Usually Skip
 
-## Implementation Notes
+- frontend の見た目
+- notification-service の内部実装
 
-- API 変更は `router.go` と `article_service.go` を対で確認する
-- データ更新を伴う変更は repository と domain の整合を崩さない
-- 収集連携に影響する変更は collector 側の投入仕様も確認する
+ただし ingest 契約変更時は collector、通知イベント変更時は notification も確認します。
+
+## Minimum Verification
+
+- `cd services/article-service && GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...`

--- a/services/collector-service/AGENT.md
+++ b/services/collector-service/AGENT.md
@@ -1,26 +1,25 @@
 # AGENT.md
 
-## Responsibility
+## Read When
 
-`collector-service` は外部ソース収集と正規化を担当します。
+- RSS 取得、正規化、dedupe、ingest payload、source 同期を変えるとき
+- 収集トリガーや publish 処理を変えるとき
 
-- RSS などの外部データを取得する
-- 記事データを正規化し `dedupe_key` を生成する
-- article-service へ取り込みを依頼する
-- 必要に応じてイベントを発行する
+## Open First
 
-## Read First
+- `internal/collector/service.go`
+- `internal/collector/service_test.go`
+- `internal/collector/service_http_test.go`
+- `internal/httpapi/routes.go`
+- `internal/events/publisher.go`
 
-- `cmd/collector-service/main.go`: 起動エントリポイント
-- `internal/app/app.go`: 設定と初期化
-- `internal/httpapi/routes.go`: 実行トリガーの HTTP 入口
-- `internal/collector/service.go`: 収集と正規化の本体
-- `internal/events/publisher.go`: イベント発行
-- `internal/collector/service_test.go`: 収集ロジックの期待仕様
-- `internal/collector/service_http_test.go`: HTTP 経由の期待仕様
+## Usually Skip
 
-## Implementation Notes
+- frontend の UI 実装
+- notification-service の一覧 API
 
-- 収集ロジック変更時は dedupe の安定性を崩さない
-- article-service への投入契約を変える場合は両サービスを同時に確認する
-- 外部入力の揺れは `internal/collector/service.go` で吸収する
+ただし ingest 契約を変える場合は article-service を同時に確認します。
+
+## Minimum Verification
+
+- `cd services/collector-service && GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...`

--- a/services/notification-service/AGENT.md
+++ b/services/notification-service/AGENT.md
@@ -1,26 +1,25 @@
 # AGENT.md
 
-## Responsibility
+## Read When
 
-`notification-service` は通知の保存、配信契約、既読管理を担います。
+- 通知一覧、既読更新、イベント消費、通知保存を変えるとき
+- 新着通知や取得失敗通知の契約を変えるとき
 
-- 通知一覧と既読更新 API を提供する
-- RabbitMQ 経由の新着通知、取得失敗通知を取り込む
-- 将来のダイジェストや外部通知連携の拡張点になる
+## Open First
 
-## Read First
+- `internal/httpapi/router.go`
+- `internal/service/notification_service.go`
+- `internal/repository/notification_repository.go`
+- `internal/events/consumer.go`
+- `internal/events/contracts.go`
 
-- `cmd/notification-service/main.go`: 起動エントリポイント
-- `internal/app/app.go`: 初期化
-- `internal/httpapi/router.go`: HTTP ルート
-- `internal/service/notification_service.go`: ユースケース
-- `internal/repository/notification_repository.go`: 永続化
-- `internal/events/consumer.go`: イベント消費
-- `internal/events/contracts.go`: イベント契約
-- `internal/domain/models.go`: ドメインモデル
+## Usually Skip
 
-## Implementation Notes
+- frontend の画面実装
+- collector の収集詳細
 
-- 通知 API の変更は `router.go` と `notification_service.go` を対で確認する
-- イベント形式を変える場合は `contracts.go` を起点に producer 側も合わせる
-- 既読更新や一覧取得の変更は repository のクエリ条件まで確認する
+ただしイベント契約変更時は producer 側の service も確認します。
+
+## Minimum Verification
+
+- `cd services/notification-service && GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...`


### PR DESCRIPTION
## 概要

- AGENT.md 群をトークン最適化前提の導線へ再編しました
- タスク別の最小読込セットを `docs/agent-playbooks.md` として追加しました

## 背景 / 目的

- エージェント作業開始時に毎回広い範囲の docs を読んでしまうと、不要なトークン消費が発生していました
- 入口 docs を薄いルータに寄せ、必要な時だけ詳細 docs を開く運用へ揃えることが目的です

## 変更内容

- ルート `AGENT.md` を最短ルータに再編
- `frontend` と各 service の `AGENT.md` を `Read When / Open First / Usually Skip / Minimum Verification` の共通形式に統一
- `docs/agent-playbooks.md` を新設し、作業種別ごとの最小読込セットと最小検証を整理
- `docs/rules-operations.md` を新しい読込導線に合わせて整理
- `README.md` のドキュメント一覧にプレイブックを追加

## 影響範囲

- [ ] frontend
- [ ] api-gateway
- [ ] collector-service
- [ ] article-service
- [ ] notification-service
- [ ] infra
- [x] docs

## 検証

- [ ] `go test ./...`
- [ ] `npm run build`
- [ ] `docker compose config -q`
- [x] その他: `git diff --check` を実行し、docs-only 変更として差分整合を確認

## API / DB / Infra への影響

- [ ] API を変更した
- [ ] DB schema を変更した
- [ ] Compose を変更した
- [ ] Kubernetes / Helm を変更した
- [x] 大きな影響はない

## ドキュメント

- [ ] 必要に応じて `RULES.md` を更新した
- [x] 関連する `docs/` を更新した
- [ ] ドキュメント更新は不要

## リスク / 注意点

- 既存のエージェント運用が旧 `AGENT.md` の読込前提に寄っている場合は、新しいプレイブック運用へ合わせる必要があります

## 補足

- docs-only 変更のため、重い検証は実施していません
