### PR TITLE
トークン読込導線を最適化

### DIFF
--- a/.rgignore
+++ b/.rgignore
@@ -1,0 +1,5 @@
+# Default searches should skip generated artifacts and lockfiles.
+frontend/node_modules/**
+frontend/dist/**
+frontend/package-lock.json
+services/**/go.sum

--- a/AGENT.md
+++ b/AGENT.md
@@ -12,7 +12,11 @@
 - `AGENT.md`
 - `docs/current-status.md`
 - 対象領域の `AGENT.md`
+
+必要なら追加で確認するもの:
+
 - `docs/agent-playbooks.md` の該当セクション
+- `docs/openapi/api-gateway.summary.md`: 公開 API の全体像だけ先に見たいとき
 
 対象領域:
 
@@ -33,6 +37,7 @@
 - `docs/db-guidelines.md`: DB や repository の責務を変えるとき
 - `docs/k8s-guidelines.md`: Helm、Argo CD、Kubernetes を変えるとき
 - `docs/requirements.md`: 要件やフェーズ適合を確認したいとき
+- `docs/openapi/api-gateway.yaml`: schema や parameter まで変更確認したいとき
 
 ## Quick Router
 
@@ -42,6 +47,7 @@
 - 収集、正規化、ingest、dedupe 変更: `services/collector-service/AGENT.md`
 - 通知 API、既読、イベント消費変更: `services/notification-service/AGENT.md`
 - docs-only 変更: `docs/agent-playbooks.md` の `Docs-Only`
+- endpoint 一覧や影響範囲だけ先に確認したい: `docs/openapi/api-gateway.summary.md`
 
 ## Non-Negotiables
 
@@ -61,7 +67,7 @@
 
 - 現在地、完了状況、次優先が変わる: `docs/current-status.md`
 - 優先順位が変わる: `docs/backlog-priority.md`
-- API 契約が変わる: `docs/openapi/api-gateway.yaml` と API 関連 docs
+- API 契約が変わる: まず `docs/openapi/api-gateway.summary.md`、schema 更新時は `docs/openapi/api-gateway.yaml` と API 関連 docs
 - DB / schema / migration 方針が変わる: DB 関連 docs
 - 起動や運用手順が変わる: `README.md` または `docs/runbook.md`
 - 恒久ルールが変わる: `RULES.md`

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Phase 1 の記事閲覧フローに加えて、Phase 2 の主要機能、Phase 3
 - `docs/backlog-priority.md`: 優先順位
 - `docs/known-issues.md`: 既知課題
 - `docs/glossary.md`: 用語集
+- `docs/openapi/api-gateway.summary.md`: 公開 API の要約導線
 - `CHANGELOG.md`: 重要変更履歴
 
 ## Standard Commands

--- a/docs/agent-playbooks.md
+++ b/docs/agent-playbooks.md
@@ -15,6 +15,7 @@
 
 必要になってから開くもの:
 
+- `docs/openapi/api-gateway.summary.md`
 - `RULES.md`
 - 領域別 guideline
 - `docs/runbook.md`
@@ -48,6 +49,7 @@
 
 - `frontend/src/store/searchStore.ts`
 - `services/api-gateway/AGENT.md`
+- `docs/openapi/api-gateway.summary.md`
 - `docs/openapi/api-gateway.yaml`
 
 ### Verification
@@ -60,13 +62,14 @@
 
 - `services/api-gateway/AGENT.md`
 - 対象 upstream service の `AGENT.md`
-- `docs/openapi/api-gateway.yaml`
+- `docs/openapi/api-gateway.summary.md`
 - `docs/api-guidelines.md`
 
 ### Read If Needed
 
 - `frontend/AGENT.md`
 - `RULES.md`
+- `docs/openapi/api-gateway.yaml`
 
 ### Verification
 

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -8,38 +8,13 @@
 
 - 現在は Phase 4 の Compose / GitHub Actions / OpenAPI 整備まで実装済み
 
-## What Is Already Implemented
+## Working Snapshot
 
-- モノレポ構成
-- `article-service` の最小 API
-  - 記事一覧
-  - 記事詳細
-  - 検索
-  - collector 向け ingest API
-- `article-service` のソース管理 API
-  - ソース一覧
-  - ソース詳細
-  - ソース作成
-  - ソース更新
-  - ソース削除
-- `api-gateway` の最小プロキシ
-- `api-gateway` 経由のソース管理 API 公開
-- `collector-service` の最小 RSS 収集フロー
-- `collector-service` の source 管理 API 連携と実行時同期
-- `frontend` の記事一覧 / 詳細 / 検索画面
-- `frontend` の記事検索結果 CSV ダウンロード
-- `frontend` のソース一覧 / 作成 / 編集 / 有効無効切り替え画面
-- `frontend` の source 詳細と取得ジョブ履歴確認画面
-- `notification-service` の通知一覧 / 既読更新 API
-- `frontend` の通知一覧画面
-- RabbitMQ 経由の新着通知 / 取得失敗通知フロー
-- MySQL 初期スキーマ
-- Docker Compose のローカル運用整備
-- ルール / 要件 / ガイドライン / ADR のドキュメント群
-- GitHub Issue / PR テンプレート
-- GitHub Actions の最小 CI
-- collector-service / api-gateway の最小ユニットテスト
-- OpenAPI の公開 API 追従
+- 記事閲覧、検索、CSV 出力、既読 / お気に入り更新は実装済み
+- ソース管理、source 詳細、取得ジョブ履歴確認は実装済み
+- collector-service は source 管理 API と同期しながら RSS 収集と ingest を実行する
+- notification-service と frontend の通知一覧 / 既読更新は実装済み
+- Docker Compose、GitHub Actions、公開 OpenAPI 追従まで整備済み
 
 ## Verified State
 

--- a/docs/openapi/api-gateway.summary.md
+++ b/docs/openapi/api-gateway.summary.md
@@ -1,0 +1,55 @@
+# API Gateway OpenAPI Summary
+
+## Purpose
+
+このファイルは、通常セッションで `docs/openapi/api-gateway.yaml` を毎回開かずに公開 API の全体像を把握するための要約です。
+
+次のケースでは summary だけを読む:
+
+- 既存 endpoint の所在を確認したい
+- frontend / gateway の参照先を素早く確認したい
+- API 変更の影響範囲をざっくり見たい
+
+次のケースでは `docs/openapi/api-gateway.yaml` も開く:
+
+- request / response schema を変える
+- query parameter や status code を追加、変更、削除する
+- OpenAPI 本体の更新漏れがないか確認する
+
+## Endpoint Groups
+
+### Health
+
+- `GET /health`
+
+### Articles
+
+- `GET /api/v1/articles`
+  - query: `q`, `category`, `source_id`, `is_read`, `is_favorite`, `from`, `to`, `page`, `page_size`
+- `GET /api/v1/articles/{id}`
+- `PATCH /api/v1/articles/{id}/read-status`
+- `PATCH /api/v1/articles/{id}/favorite-status`
+- `GET /api/v1/exports/articles.csv`
+  - query: article list に加えて `sort`, `order`
+
+### Sources
+
+- `GET /api/v1/sources`
+- `POST /api/v1/sources`
+- `GET /api/v1/sources/{id}`
+- `PATCH /api/v1/sources/{id}`
+- `DELETE /api/v1/sources/{id}`
+- `GET /api/v1/fetch-jobs`
+  - query: `source_id`, `status`, `page`, `page_size`
+
+### Notifications
+
+- `GET /api/v1/notifications`
+  - query: `is_read`, `page`, `page_size`
+- `PATCH /api/v1/notifications/{id}/read-status`
+
+## Notes
+
+- frontend からの入口は `api-gateway` に集約する
+- source 管理と notification API も gateway 経由で公開する
+- 詳細 schema は `docs/openapi/api-gateway.yaml` を正本として扱う

--- a/docs/rules-operations.md
+++ b/docs/rules-operations.md
@@ -22,6 +22,7 @@
 - `docs/branch-strategy.md`
 - `docs/adr/*`
 - `docs/current-status.md`
+- `docs/openapi/api-gateway.summary.md`
 - `docs/backlog-priority.md`
 - `docs/known-issues.md`
 - `docs/glossary.md`
@@ -60,18 +61,20 @@
 - `AGENT.md`
 - `docs/current-status.md`
 - 対象領域の `AGENT.md`
-- `docs/agent-playbooks.md` の該当セクション
 
 ### Read On Demand
 
 以下は必要になった時だけ開く。
 
+- `docs/agent-playbooks.md`: 作業別の最小読込セットを確認する時
+- `docs/openapi/api-gateway.summary.md`: 公開 API の全体像を素早く確認する時
 - `RULES.md`: スコープ、責務、全体方針を変える時
 - `docs/backlog-priority.md`: 次の Issue を選ぶ時
 - `docs/branch-strategy.md`: branch / PR / merge 運用を確認する時
 - `docs/test-policy.md`: テスト追加判断に迷う時
 - `docs/runbook.md`: 起動、障害切り分け、運用手順が必要な時
 - `docs/api-guidelines.md`: 公開 API を変える時
+- `docs/openapi/api-gateway.yaml`: schema や parameter まで変更する時
 - `docs/db-guidelines.md`: DB、repository、migration を変える時
 - `docs/k8s-guidelines.md`: Kubernetes、Helm、Argo CD を変える時
 - `docs/requirements.md`: 要件適合に不安がある時
@@ -86,7 +89,7 @@
 
 ### When Implementing
 
-- API 変更時は OpenAPI 更新対象か確認する
+- API 変更時は summary で影響範囲を見て、詳細変更時だけ OpenAPI 本体を開く
 - DB 変更時は init SQL / migration / repository 整合を確認する
 - docs 更新対象を同じ変更内で処理する
 - 処理意図が追いにくい箇所には日本語コメントを補う
@@ -200,7 +203,7 @@
 ## Session Continuity
 
 - セッション開始時は `docs/current-status.md` を確認する
-- 作業ごとに `docs/agent-playbooks.md` の該当セクションを使う
+- 作業ごとに必要なら `docs/agent-playbooks.md` の該当セクションを使う
 - 優先順位判断は `docs/backlog-priority.md` を使う
 - 既知制約は `docs/known-issues.md` を確認する
 - 標準検証は `make verify` を使う

--- a/services/api-gateway/AGENT.md
+++ b/services/api-gateway/AGENT.md
@@ -11,6 +11,7 @@
 - `internal/httpapi/middleware.go`
 - `internal/httpapi/routes_test.go`
 - `internal/app/app.go`
+- `../../docs/openapi/api-gateway.summary.md`
 
 ## Usually Skip
 
@@ -18,6 +19,7 @@
 - collector / notification の内部詳細
 
 ただし upstream 契約を変える場合は対象サービスの `AGENT.md` も開きます。
+schema や parameter まで変える場合は `../../docs/openapi/api-gateway.yaml` も開きます。
 
 ## Minimum Verification
 


### PR DESCRIPTION
## 概要

- エージェントの通常読込を軽くするため、要約導線と検索除外を追加

## 背景 / 目的

- `docs/openapi/api-gateway.yaml` や lockfile を毎回読まなくても作業開始できる状態にしたい
- ただし OpenAPI 本体や詳細 docs を不要に隠さず、必要時に辿れる導線は維持したい

## 変更内容

- `.rgignore` を追加し、生成物と lockfile を既定検索から除外
- `docs/openapi/api-gateway.summary.md` を追加し、公開 API の要約導線を新設
- `AGENT.md` / `docs/agent-playbooks.md` / `docs/rules-operations.md` / `services/api-gateway/AGENT.md` を更新し、summary 優先・詳細は on-demand の読込方針に変更
- `docs/current-status.md` を要点中心の `Working Snapshot` に圧縮
- `README.md` に新しい OpenAPI 要約導線を追記

## 影響範囲

- [ ] frontend
- [ ] api-gateway
- [ ] collector-service
- [ ] article-service
- [ ] notification-service
- [ ] infra
- [x] docs

## 検証

- [ ] `go test ./...`
- [ ] `npm run build`
- [ ] `docker compose config -q`
- [x] その他: docs-only 変更のため、参照リンク・OpenAPI summary と本体定義の整合・`.rgignore` の対象確認を実施

## API / DB / Infra への影響

- [ ] API を変更した
- [ ] DB schema を変更した
- [ ] Compose を変更した
- [ ] Kubernetes / Helm を変更した
- [x] 大きな影響はない

## ドキュメント

- [ ] 必要に応じて `RULES.md` を更新した
- [x] 関連する `docs/` を更新した
- [ ] ドキュメント更新は不要

## リスク / 注意点

- `docs/openapi/api-gateway.summary.md` は要約資料のため、schema や status code を変更する場合は引き続き `docs/openapi/api-gateway.yaml` を正本として更新する必要があります

## 補足

- `docs/test-policy.md` の docs-only 方針に合わせて、重い `make verify` は省略しています
