### PR TITLE
ローカル開発にホットリロード構成を追加

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@
 **/*.tsbuildinfo
 frontend/vite.config.js
 frontend/vite.config.d.ts
+services/*/tmp

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ frontend/vite.config.d.ts
 
 # Docker / compose local data
 mysql_data/
+services/*/tmp/

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,39 @@
 -include .env
 
-.PHONY: up down reset logs ps build test verify
+COMPOSE := docker compose
+DEV_COMPOSE := docker compose -f docker-compose.yml -f docker-compose.dev.yml
+
+.PHONY: up down reset logs ps dev-up dev-down dev-logs dev-ps dev-config build test verify
 
 up:
-	docker compose up --build
+	$(COMPOSE) up --build
 
 down:
-	docker compose down
+	$(COMPOSE) down
 
 reset:
-	docker compose down -v
+	$(COMPOSE) down -v
 
 logs:
-	docker compose logs -f
+	$(COMPOSE) logs -f
 
 ps:
-	docker compose ps
+	$(COMPOSE) ps
+
+dev-up:
+	$(DEV_COMPOSE) up --build
+
+dev-down:
+	$(DEV_COMPOSE) down
+
+dev-logs:
+	$(DEV_COMPOSE) logs -f
+
+dev-ps:
+	$(DEV_COMPOSE) ps
+
+dev-config:
+	$(DEV_COMPOSE) config -q
 
 build:
 	cd frontend && npm run build
@@ -27,4 +45,4 @@ test:
 	cd services/notification-service && GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...
 
 verify: test build
-	docker compose config -q
+	$(COMPOSE) config -q

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ Phase 1 の記事閲覧フローに加えて、Phase 2 の主要機能、Phase 3
 - `make up`: 全サービス起動
 - `make down`: volume を残して停止
 - `make reset`: volume を削除して初期化
+- `make dev-up`: frontend HMR と Go auto-reload 付きで起動
+- `make dev-down`: dev compose を停止
+- `make dev-logs`: dev compose のログ追跡
+- `make dev-ps`: dev compose の状態確認
 - `make build`: frontend build
 - `make test`: backend test
 - `make verify`: test + build + compose config check
@@ -89,3 +93,4 @@ Phase 1 の記事閲覧フローに加えて、Phase 2 の主要機能、Phase 3
 - 通常のコード変更では CI も `make verify` 相当を実行します
 - docs-only 変更では、GitHub Actions は required check を維持しつつ重い検証を省略します
 - collector-service は `ARTICLE_SERVICE_URL` 経由で source 一覧を取得し、`is_enabled=true` の source を収集します
+- ローカルで即時反映が必要な場合は `docker-compose.dev.yml` を重ねる `make dev-up` を使います

--- a/deployments/docker/frontend.Dockerfile
+++ b/deployments/docker/frontend.Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22-alpine
 WORKDIR /app
-COPY frontend/package.json ./
-RUN npm install
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
 COPY frontend ./
 EXPOSE 5173
 CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]

--- a/deployments/docker/go-dev.Dockerfile
+++ b/deployments/docker/go-dev.Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.24-alpine
+
+WORKDIR /workspace
+
+RUN apk add --no-cache bash ca-certificates git \
+    && go install github.com/air-verse/air@v1.61.7
+
+ENV PATH="/go/bin:${PATH}"
+
+CMD ["air", "-c", ".air.toml"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,61 @@
+services:
+  article-service:
+    build:
+      context: .
+      dockerfile: deployments/docker/go-dev.Dockerfile
+    working_dir: /workspace
+    command: ["air", "-c", ".air.toml"]
+    volumes:
+      - ./services/article-service:/workspace
+      - go_mod_cache:/go/pkg/mod
+      - go_build_cache:/root/.cache/go-build
+
+  api-gateway:
+    build:
+      context: .
+      dockerfile: deployments/docker/go-dev.Dockerfile
+    working_dir: /workspace
+    command: ["air", "-c", ".air.toml"]
+    volumes:
+      - ./services/api-gateway:/workspace
+      - go_mod_cache:/go/pkg/mod
+      - go_build_cache:/root/.cache/go-build
+
+  collector-service:
+    build:
+      context: .
+      dockerfile: deployments/docker/go-dev.Dockerfile
+    working_dir: /workspace
+    command: ["air", "-c", ".air.toml"]
+    volumes:
+      - ./services/collector-service:/workspace
+      - go_mod_cache:/go/pkg/mod
+      - go_build_cache:/root/.cache/go-build
+
+  notification-service:
+    build:
+      context: .
+      dockerfile: deployments/docker/go-dev.Dockerfile
+    working_dir: /workspace
+    command: ["air", "-c", ".air.toml"]
+    volumes:
+      - ./services/notification-service:/workspace
+      - go_mod_cache:/go/pkg/mod
+      - go_build_cache:/root/.cache/go-build
+
+  frontend:
+    command:
+      - sh
+      - -c
+      - if [ ! -f node_modules/.package-lock.hash ] || ! sha256sum -c node_modules/.package-lock.hash >/dev/null 2>&1; then npm ci && sha256sum package-lock.json > node_modules/.package-lock.hash; fi && npm run dev -- --host 0.0.0.0
+    environment:
+      CHOKIDAR_USEPOLLING: "true"
+      VITE_USE_POLLING: "true"
+    volumes:
+      - ./frontend:/app
+      - frontend_node_modules:/app/node_modules
+
+volumes:
+  frontend_node_modules:
+  go_mod_cache:
+  go_build_cache:

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -24,10 +24,30 @@ docker compose config -q
 make up
 ```
 
+### Start With Hot Reload
+
+```bash
+make dev-up
+```
+
+補足:
+
+- frontend は Vite HMR で即時反映する
+- Go services は `air` で build / restart される
+- 初回起動では dev image build と依存取得に時間がかかる
+- dev 用 compose は `docker-compose.yml` に `docker-compose.dev.yml` を重ねて使う
+- frontend 依存が変わった場合も `package-lock.json` を見て `npm ci` を再実行する
+
 ### Stop
 
 ```bash
 make down
+```
+
+### Stop Hot Reload Stack
+
+```bash
+make dev-down
 ```
 
 補足:
@@ -39,6 +59,12 @@ make down
 
 ```bash
 make logs
+```
+
+### Dev Logs
+
+```bash
+make dev-logs
 ```
 
 ## Basic Verification
@@ -64,6 +90,12 @@ npm run build
 
 ```bash
 docker compose config -q
+```
+
+### Dev Compose Config
+
+```bash
+make dev-config
 ```
 
 ### Full Verify

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,5 +6,12 @@ export default defineConfig({
   server: {
     host: "0.0.0.0",
     port: 5173,
+    watch:
+      process.env.VITE_USE_POLLING === "true"
+        ? {
+            usePolling: true,
+            interval: 300,
+          }
+        : undefined,
   },
 });

--- a/services/api-gateway/.air.toml
+++ b/services/api-gateway/.air.toml
@@ -1,0 +1,13 @@
+root = "."
+tmp_dir = "tmp"
+
+[build]
+cmd = "go build -o ./tmp/api-gateway ./cmd/api-gateway"
+bin = "./tmp/api-gateway"
+delay = 200
+exclude_dir = ["tmp", "vendor"]
+include_ext = ["go"]
+stop_on_error = true
+
+[log]
+time = true

--- a/services/article-service/.air.toml
+++ b/services/article-service/.air.toml
@@ -1,0 +1,13 @@
+root = "."
+tmp_dir = "tmp"
+
+[build]
+cmd = "go build -o ./tmp/article-service ./cmd/article-service"
+bin = "./tmp/article-service"
+delay = 200
+exclude_dir = ["tmp", "vendor"]
+include_ext = ["go"]
+stop_on_error = true
+
+[log]
+time = true

--- a/services/collector-service/.air.toml
+++ b/services/collector-service/.air.toml
@@ -1,0 +1,13 @@
+root = "."
+tmp_dir = "tmp"
+
+[build]
+cmd = "go build -o ./tmp/collector-service ./cmd/collector-service"
+bin = "./tmp/collector-service"
+delay = 200
+exclude_dir = ["tmp", "vendor"]
+include_ext = ["go"]
+stop_on_error = true
+
+[log]
+time = true

--- a/services/notification-service/.air.toml
+++ b/services/notification-service/.air.toml
@@ -1,0 +1,13 @@
+root = "."
+tmp_dir = "tmp"
+
+[build]
+cmd = "go build -o ./tmp/notification-service ./cmd/notification-service"
+bin = "./tmp/notification-service"
+delay = 200
+exclude_dir = ["tmp", "vendor"]
+include_ext = ["go"]
+stop_on_error = true
+
+[log]
+time = true


### PR DESCRIPTION
## 概要

- frontend HMR と Go auto-reload を使える local dev 用 compose override を追加

## 背景 / 目的

- 現在の `docker-compose.yml` は production 寄りの build 済み binary / bundled source 前提で、コード変更を即時反映できない
- 本番向け構成は維持したまま、ローカル開発だけ軽く回せる起動経路を追加したい

## 変更内容

- `docker-compose.dev.yml` を追加し、base compose に重ねる dev 用 override を定義
- Go services 向けに `deployments/docker/go-dev.Dockerfile` と各 service の `.air.toml` を追加
- `frontend` は bind mount + named volume + polling watch で HMR できるように変更
- `Makefile` に `make dev-up`, `make dev-down`, `make dev-logs`, `make dev-ps`, `make dev-config` を追加
- `deployments/docker/frontend.Dockerfile` を `npm ci` ベースに更新
- `README.md` と `docs/runbook.md` に dev 起動手順を追記
- `services/*/tmp` を ignore に追加

## 影響範囲

- [x] frontend
- [x] api-gateway
- [x] collector-service
- [x] article-service
- [x] notification-service
- [x] infra
- [x] docs

## 検証

- [x] `go test ./...`
- [x] `npm run build`
- [x] `docker compose config -q`
- [x] その他: `make verify`
- [x] その他: `make dev-config`

## API / DB / Infra への影響

- [ ] API を変更した
- [ ] DB schema を変更した
- [ ] Compose を変更した
- [ ] Kubernetes / Helm を変更した
- [x] 大きな影響はない

## ドキュメント

- [ ] 必要に応じて `RULES.md` を更新した
- [x] 関連する `docs/` を更新した
- [ ] ドキュメント更新は不要

## リスク / 注意点

- `make dev-up` は `docker-compose.yml` に `docker-compose.dev.yml` を重ねる前提
- Go service のホットリロードは `air` に依存するため、初回 build 時に dev image の作成が発生する
- frontend 依存は `package-lock.json` のハッシュ差分を見て `npm ci` を再実行する

## 補足

- 既存の `make up` / `docker-compose.yml` は production 寄りの挙動のまま維持している
