### PR TITLE
article-service の repository / handler 向け integration test を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 COMPOSE := docker compose
 DEV_COMPOSE := docker compose -f docker-compose.yml -f docker-compose.dev.yml
 
-.PHONY: up down reset logs ps dev-up dev-down dev-logs dev-ps dev-config build test verify
+.PHONY: up down reset logs ps dev-up dev-down dev-logs dev-ps dev-config build test test-article-integration verify
 
 up:
 	$(COMPOSE) up --build
@@ -43,6 +43,9 @@ test:
 	cd services/api-gateway && GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...
 	cd services/collector-service && GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...
 	cd services/notification-service && GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...
+
+test-article-integration:
+	cd services/article-service && ARTICLE_SERVICE_RUN_INTEGRATION=1 GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...
 
 verify: test build
 	$(COMPOSE) config -q

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -78,6 +78,19 @@ cd services/collector-service && GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go
 cd services/notification-service && GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...
 ```
 
+### article-service MySQL Integration Test
+
+```bash
+docker compose up -d mysql
+ARTICLE_SERVICE_TEST_MYSQL_DSN='app_user:app_password@tcp(127.0.0.1:3306)/tech_feed_hub?parseTime=true&multiStatements=true' make test-article-integration
+```
+
+補足:
+
+- integration test は `ARTICLE_SERVICE_RUN_INTEGRATION=1` が付いたときだけ実行される
+- `ARTICLE_SERVICE_TEST_MYSQL_DSN` を省略した場合は `127.0.0.1:3306` のローカル MySQL を既定で参照する
+- schema は `deployments/compose/mysql/init/001_schema.sql` をそのまま適用する
+
 ### Frontend
 
 ```bash

--- a/services/article-service/internal/httpapi/router.go
+++ b/services/article-service/internal/httpapi/router.go
@@ -74,7 +74,7 @@ func NewRouter(db *sql.DB, articleService *service.ArticleService) *gin.Engine {
 
 			article, err := articleService.GetArticle(c.Request.Context(), id)
 			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				writeServiceError(c, err)
 				return
 			}
 			if article == nil {
@@ -267,7 +267,7 @@ func NewRouter(db *sql.DB, articleService *service.ArticleService) *gin.Engine {
 			// ingest 単体の失敗は collector が finish API で閉じるため、ここでは記事登録結果だけ返す。
 			result, err := articleService.Ingest(c.Request.Context(), req)
 			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				writeServiceError(c, err)
 				return
 			}
 

--- a/services/article-service/internal/httpapi/router_integration_test.go
+++ b/services/article-service/internal/httpapi/router_integration_test.go
@@ -1,0 +1,244 @@
+package httpapi
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"tech-feed-hub/article-service/internal/domain"
+	"tech-feed-hub/article-service/internal/repository"
+	"tech-feed-hub/article-service/internal/service"
+	"tech-feed-hub/article-service/internal/testutil"
+)
+
+func TestRouterArticleEndpointsAndCSV(t *testing.T) {
+	db, router := newIntegrationRouter(t)
+
+	sourceID := testutil.InsertSource(t, db, domain.Source{
+		Name:            "Router Source",
+		Type:            "rss",
+		FetchURL:        "https://example.com/router.xml",
+		FetchMethod:     "rss",
+		IntervalMinutes: 30,
+		DefaultCategory: "k8s",
+		IsEnabled:       true,
+	})
+	published := time.Date(2026, 4, 16, 8, 0, 0, 0, time.UTC)
+	articleID := testutil.InsertArticle(t, db, domain.Article{
+		Title:       "Router article",
+		URL:         "https://example.com/router-article",
+		SourceID:    sourceID,
+		PublishedAt: &published,
+		FetchedAt:   published.Add(time.Minute),
+		Excerpt:     "router excerpt",
+		Category:    "k8s",
+		Tags:        []string{"router"},
+		IsRead:      false,
+		IsFavorite:  true,
+		DedupeKey:   "router-article",
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/articles?is_read=bad", nil)
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid bool query, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/articles?q=Router&is_favorite=true", nil)
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for article list, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var listResp struct {
+		Items []domain.Article `json:"items"`
+		Total int              `json:"total"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &listResp); err != nil {
+		t.Fatalf("unmarshal article list: %v", err)
+	}
+	if listResp.Total != 1 || len(listResp.Items) != 1 || listResp.Items[0].ID != articleID {
+		t.Fatalf("unexpected list response: %+v", listResp)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/articles/999999", nil)
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing article, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPatch, "/api/v1/articles/999999/favorite-status", strings.NewReader(`{"is_favorite":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing favorite target, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/articles/export.csv?source_id=1", nil)
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for csv export, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Type"); got != "text/csv; charset=utf-8" {
+		t.Fatalf("unexpected csv content type: %s", got)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "title,url,source_name,category,published_at,fetched_at,is_read,is_favorite,excerpt,tags") || !strings.Contains(body, "Router article") {
+		t.Fatalf("unexpected csv body: %s", body)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/articles/export.csv?from=bad", nil)
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid from query, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRouterSourceEndpointsAndServerError(t *testing.T) {
+	db, router := newIntegrationRouter(t)
+
+	sourceID := testutil.InsertSource(t, db, domain.Source{
+		Name:            "Existing Source",
+		Type:            "rss",
+		FetchURL:        "https://example.com/existing.xml",
+		FetchMethod:     "rss",
+		IntervalMinutes: 60,
+		DefaultCategory: "ops",
+		IsEnabled:       true,
+	})
+	published := time.Date(2026, 4, 16, 9, 0, 0, 0, time.UTC)
+	testutil.InsertArticle(t, db, domain.Article{
+		Title:       "Dependent",
+		URL:         "https://example.com/dependent",
+		SourceID:    sourceID,
+		PublishedAt: &published,
+		FetchedAt:   published,
+		Category:    "ops",
+		DedupeKey:   "dependent",
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sources", strings.NewReader(`{"name":"Existing Source","type":"rss","fetch_url":"https://example.com/another.xml","fetch_method":"rss","interval_minutes":15,"default_category":"ops","is_enabled":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for duplicate source, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodDelete, "/api/v1/sources/"+int64String(sourceID), nil)
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for referenced source delete, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db for 500 test: %v", err)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/sources", nil)
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 after db close, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRouterFetchJobEndpointsAndIngestConflict(t *testing.T) {
+	db, router := newIntegrationRouter(t)
+
+	sourceID := testutil.InsertSource(t, db, domain.Source{
+		Name:            "Job Source",
+		Type:            "rss",
+		FetchURL:        "https://example.com/jobs.xml",
+		FetchMethod:     "rss",
+		IntervalMinutes: 20,
+		DefaultCategory: "jobs",
+		IsEnabled:       true,
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/fetch-jobs", nil)
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing source_id, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/internal/fetch-jobs/start", strings.NewReader(`{"source_id":999999}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing start source, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/internal/fetch-jobs/start", strings.NewReader(`{"source_id":`+int64String(sourceID)+`}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202 for start fetch job, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var startResp struct {
+		SourceID int64 `json:"source_id"`
+		JobID    int64 `json:"job_id"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &startResp); err != nil {
+		t.Fatalf("unmarshal start fetch job response: %v", err)
+	}
+	if startResp.SourceID != sourceID || startResp.JobID < 1 {
+		t.Fatalf("unexpected start response: %+v", startResp)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/internal/fetch-jobs/"+int64String(startResp.JobID)+"/finish", bytes.NewBufferString(`{"status":"failed","fetched_count":3,"inserted_count":1,"duplicated_count":2,"error_message":"network error"}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 for finish fetch job, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/internal/fetch-jobs/"+int64String(startResp.JobID)+"/finish", bytes.NewBufferString(`{"status":"success","fetched_count":3,"inserted_count":1,"duplicated_count":2}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for finishing completed job, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/internal/ingest", bytes.NewBufferString(`{"job_id":`+int64String(startResp.JobID)+`,"source_id":`+int64String(sourceID)+`,"source":{"name":"Job Source","default_category":"jobs"},"articles":[{"title":"New article","url":"https://example.com/new","fetched_at":"2026-04-16T10:00:00Z","dedupe_key":"new-article"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for ingest on finished job, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func newIntegrationRouter(t *testing.T) (*sql.DB, http.Handler) {
+	t.Helper()
+
+	db := testutil.OpenMySQLForTest(t)
+	testutil.ResetMySQLTables(t, db)
+
+	articleRepo := repository.NewArticleRepository(db)
+	sourceRepo := repository.NewSourceRepository(db)
+	jobRepo := repository.NewFetchJobRepository(db)
+	articleService := service.NewArticleService(articleRepo, sourceRepo, jobRepo)
+
+	return db, NewRouter(db, articleService)
+}
+
+func int64String(value int64) string {
+	return strconv.FormatInt(value, 10)
+}

--- a/services/article-service/internal/httpapi/router_integration_test.go
+++ b/services/article-service/internal/httpapi/router_integration_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestRouterArticleEndpointsAndCSV(t *testing.T) {
+	// 記事系 endpoint の 400/404/200 と CSV content-type をまとめて確認する。
 	db, router := newIntegrationRouter(t)
 
 	sourceID := testutil.InsertSource(t, db, domain.Source{
@@ -68,6 +69,7 @@ func TestRouterArticleEndpointsAndCSV(t *testing.T) {
 		t.Fatalf("unexpected list response: %+v", listResp)
 	}
 
+	// 詳細と状態更新は未存在 article を 404 にそろえる必要がある。
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/api/v1/articles/999999", nil)
 	router.ServeHTTP(rec, req)
@@ -83,6 +85,7 @@ func TestRouterArticleEndpointsAndCSV(t *testing.T) {
 		t.Fatalf("expected 404 for missing favorite target, got %d body=%s", rec.Code, rec.Body.String())
 	}
 
+	// CSV endpoint は成功時ヘッダと本文の両方を確認する。
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/api/v1/articles/export.csv?source_id=1", nil)
 	router.ServeHTTP(rec, req)
@@ -96,6 +99,7 @@ func TestRouterArticleEndpointsAndCSV(t *testing.T) {
 		t.Fatalf("unexpected csv body: %s", body)
 	}
 
+	// query parse failure は service まで入る前に 400 を返す。
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/api/v1/articles/export.csv?from=bad", nil)
 	router.ServeHTTP(rec, req)
@@ -105,6 +109,7 @@ func TestRouterArticleEndpointsAndCSV(t *testing.T) {
 }
 
 func TestRouterSourceEndpointsAndServerError(t *testing.T) {
+	// source 系 endpoint の 409 と、repository 障害時の 500 を確認する。
 	db, router := newIntegrationRouter(t)
 
 	sourceID := testutil.InsertSource(t, db, domain.Source{
@@ -135,6 +140,7 @@ func TestRouterSourceEndpointsAndServerError(t *testing.T) {
 		t.Fatalf("expected 409 for duplicate source, got %d body=%s", rec.Code, rec.Body.String())
 	}
 
+	// 参照中 source の削除失敗も 409 に統一する。
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodDelete, "/api/v1/sources/"+int64String(sourceID), nil)
 	router.ServeHTTP(rec, req)
@@ -146,6 +152,7 @@ func TestRouterSourceEndpointsAndServerError(t *testing.T) {
 		t.Fatalf("close db for 500 test: %v", err)
 	}
 
+	// DB 障害は writeServiceError 経由で 500 になる。
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/api/v1/sources", nil)
 	router.ServeHTTP(rec, req)
@@ -155,6 +162,7 @@ func TestRouterSourceEndpointsAndServerError(t *testing.T) {
 }
 
 func TestRouterFetchJobEndpointsAndIngestConflict(t *testing.T) {
+	// fetch job 系 endpoint の 400/404/202/204/409 を一通り確認する。
 	db, router := newIntegrationRouter(t)
 
 	sourceID := testutil.InsertSource(t, db, domain.Source{
@@ -174,6 +182,7 @@ func TestRouterFetchJobEndpointsAndIngestConflict(t *testing.T) {
 		t.Fatalf("expected 400 for missing source_id, got %d body=%s", rec.Code, rec.Body.String())
 	}
 
+	// start は未存在 source を 404 にし、既存 source は 202 で job を返す。
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodPost, "/internal/fetch-jobs/start", strings.NewReader(`{"source_id":999999}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -200,6 +209,7 @@ func TestRouterFetchJobEndpointsAndIngestConflict(t *testing.T) {
 		t.Fatalf("unexpected start response: %+v", startResp)
 	}
 
+	// finish は初回のみ成功し、完了済み job の再完了は conflict になる。
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodPost, "/internal/fetch-jobs/"+int64String(startResp.JobID)+"/finish", bytes.NewBufferString(`{"status":"failed","fetched_count":3,"inserted_count":1,"duplicated_count":2,"error_message":"network error"}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -216,6 +226,7 @@ func TestRouterFetchJobEndpointsAndIngestConflict(t *testing.T) {
 		t.Fatalf("expected 409 for finishing completed job, got %d body=%s", rec.Code, rec.Body.String())
 	}
 
+	// ingest も完了済み job に対しては conflict を返す。
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodPost, "/internal/ingest", bytes.NewBufferString(`{"job_id":`+int64String(startResp.JobID)+`,"source_id":`+int64String(sourceID)+`,"source":{"name":"Job Source","default_category":"jobs"},"articles":[{"title":"New article","url":"https://example.com/new","fetched_at":"2026-04-16T10:00:00Z","dedupe_key":"new-article"}]}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -228,6 +239,7 @@ func TestRouterFetchJobEndpointsAndIngestConflict(t *testing.T) {
 func newIntegrationRouter(t *testing.T) (*sql.DB, http.Handler) {
 	t.Helper()
 
+	// router test は本番と同じ repository/service 構成を立てて handler 境界を見る。
 	db := testutil.OpenMySQLForTest(t)
 	testutil.ResetMySQLTables(t, db)
 

--- a/services/article-service/internal/repository/article_repository_integration_test.go
+++ b/services/article-service/internal/repository/article_repository_integration_test.go
@@ -1,0 +1,233 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"tech-feed-hub/article-service/internal/domain"
+	"tech-feed-hub/article-service/internal/testutil"
+)
+
+func TestArticleRepositoryListExportAndStatusUpdates(t *testing.T) {
+	db := testutil.OpenMySQLForTest(t)
+	testutil.ResetMySQLTables(t, db)
+
+	repo := NewArticleRepository(db)
+
+	sourceAID := testutil.InsertSource(t, db, domain.Source{
+		Name:            "Source A",
+		Type:            "rss",
+		FetchURL:        "https://example.com/a.xml",
+		FetchMethod:     "rss",
+		IntervalMinutes: 60,
+		DefaultCategory: "k8s",
+		IsEnabled:       true,
+	})
+	sourceBID := testutil.InsertSource(t, db, domain.Source{
+		Name:            "Source B",
+		Type:            "rss",
+		FetchURL:        "https://example.com/b.xml",
+		FetchMethod:     "rss",
+		IntervalMinutes: 30,
+		DefaultCategory: "infra",
+		IsEnabled:       true,
+	})
+
+	publishedA1 := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+	publishedA2 := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
+	fetchedBase := time.Date(2026, 4, 12, 11, 0, 0, 0, time.UTC)
+
+	articleA1ID := testutil.InsertArticle(t, db, domain.Article{
+		Title:       "Kubernetes release",
+		URL:         "https://example.com/articles/1",
+		SourceID:    sourceAID,
+		PublishedAt: &publishedA1,
+		FetchedAt:   fetchedBase,
+		Excerpt:     "release note",
+		Category:    "k8s",
+		Tags:        []string{"go", "k8s"},
+		IsRead:      false,
+		IsFavorite:  true,
+		DedupeKey:   "dedupe-1",
+	})
+	testutil.InsertArticle(t, db, domain.Article{
+		Title:       "Kubernetes deep dive",
+		URL:         "https://example.com/articles/2",
+		SourceID:    sourceAID,
+		PublishedAt: &publishedA2,
+		FetchedAt:   fetchedBase.Add(2 * time.Hour),
+		Excerpt:     "deep dive",
+		Category:    "k8s",
+		Tags:        []string{"k8s"},
+		IsRead:      false,
+		IsFavorite:  true,
+		DedupeKey:   "dedupe-2",
+	})
+	testutil.InsertArticle(t, db, domain.Article{
+		Title:      "Terraform plan",
+		URL:        "https://example.com/articles/3",
+		SourceID:   sourceBID,
+		FetchedAt:  fetchedBase.Add(time.Hour),
+		Excerpt:    "iac",
+		Category:   "infra",
+		Tags:       []string{"terraform"},
+		IsRead:     true,
+		IsFavorite: false,
+		DedupeKey:  "dedupe-3",
+	})
+
+	isRead := false
+	isFavorite := true
+	from := time.Date(2026, 4, 9, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 4, 13, 0, 0, 0, 0, time.UTC)
+	listResult, err := repo.List(context.Background(), domain.ListArticlesParams{
+		ArticleFilterParams: domain.ArticleFilterParams{
+			Query:         "Kubernetes",
+			Category:      "k8s",
+			SourceID:      sourceAID,
+			IsRead:        &isRead,
+			IsFavorite:    &isFavorite,
+			PublishedFrom: &from,
+			PublishedTo:   &to,
+		},
+		Page:     1,
+		PageSize: 1,
+	})
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if listResult.Total != 2 || listResult.TotalPages != 2 || len(listResult.Items) != 1 {
+		t.Fatalf("unexpected list meta: %+v", listResult)
+	}
+	if got := listResult.Items[0]; got.Title != "Kubernetes deep dive" || got.SourceName != "Source A" {
+		t.Fatalf("unexpected first item: %+v", got)
+	}
+
+	exported, err := repo.Export(context.Background(), domain.ExportArticlesParams{
+		ArticleFilterParams: domain.ArticleFilterParams{
+			SourceID:   sourceAID,
+			Sort:       "created_at",
+			Order:      "asc",
+			IsFavorite: &isFavorite,
+		},
+		Limit: 1,
+	})
+	if err != nil {
+		t.Fatalf("Export returned error: %v", err)
+	}
+	if len(exported) != 2 {
+		t.Fatalf("expected limit+1 rows for over-limit detection, got %d", len(exported))
+	}
+	if exported[0].Title != "Kubernetes release" || exported[1].Title != "Kubernetes deep dive" {
+		t.Fatalf("unexpected export order: %+v", exported)
+	}
+
+	updatedRead, err := repo.UpdateReadStatus(context.Background(), articleA1ID, true)
+	if err != nil {
+		t.Fatalf("UpdateReadStatus returned error: %v", err)
+	}
+	if updatedRead == nil || !updatedRead.IsRead {
+		t.Fatalf("unexpected read-status update result: %+v", updatedRead)
+	}
+
+	updatedFavorite, err := repo.UpdateFavoriteStatus(context.Background(), articleA1ID, false)
+	if err != nil {
+		t.Fatalf("UpdateFavoriteStatus returned error: %v", err)
+	}
+	if updatedFavorite == nil || updatedFavorite.IsFavorite {
+		t.Fatalf("unexpected favorite-status update result: %+v", updatedFavorite)
+	}
+
+	missing, err := repo.UpdateFavoriteStatus(context.Background(), 999999, true)
+	if err != nil {
+		t.Fatalf("unexpected missing update error: %v", err)
+	}
+	if missing != nil {
+		t.Fatalf("expected nil for missing article, got %+v", missing)
+	}
+}
+
+func TestArticleRepositoryBulkUpsertCountsInsertedAndDuplicated(t *testing.T) {
+	db := testutil.OpenMySQLForTest(t)
+	testutil.ResetMySQLTables(t, db)
+
+	repo := NewArticleRepository(db)
+	sourceID := testutil.InsertSource(t, db, domain.Source{
+		Name:            "Collector",
+		Type:            "rss",
+		FetchURL:        "https://example.com/feed.xml",
+		FetchMethod:     "rss",
+		IntervalMinutes: 15,
+		DefaultCategory: "cloud",
+		IsEnabled:       true,
+	})
+
+	published := time.Date(2026, 4, 14, 9, 0, 0, 0, time.UTC)
+	fetched := time.Date(2026, 4, 14, 9, 30, 0, 0, time.UTC)
+	inserted, duplicated, err := repo.BulkUpsert(context.Background(), sourceID, []domain.Article{
+		{
+			Title:       "First title",
+			URL:         "https://example.com/first",
+			PublishedAt: &published,
+			FetchedAt:   fetched,
+			Excerpt:     "first",
+			Category:    "cloud",
+			Tags:        []string{"aws"},
+			DedupeKey:   "bulk-1",
+		},
+		{
+			Title:       "Second title",
+			URL:         "https://example.com/second",
+			PublishedAt: &published,
+			FetchedAt:   fetched.Add(time.Minute),
+			Excerpt:     "second",
+			Category:    "cloud",
+			Tags:        []string{"gcp"},
+			DedupeKey:   "bulk-2",
+		},
+	})
+	if err != nil {
+		t.Fatalf("initial BulkUpsert returned error: %v", err)
+	}
+	if inserted != 2 || duplicated != 0 {
+		t.Fatalf("unexpected initial counts: inserted=%d duplicated=%d", inserted, duplicated)
+	}
+
+	inserted, duplicated, err = repo.BulkUpsert(context.Background(), sourceID, []domain.Article{
+		{
+			Title:       "First title updated",
+			URL:         "https://example.com/first",
+			PublishedAt: &published,
+			FetchedAt:   fetched,
+			Excerpt:     "updated",
+			Category:    "cloud",
+			Tags:        []string{"aws", "eks"},
+			DedupeKey:   "bulk-1",
+		},
+		{
+			Title:       "Third title",
+			URL:         "https://example.com/third",
+			PublishedAt: &published,
+			FetchedAt:   fetched.Add(2 * time.Minute),
+			Excerpt:     "third",
+			Category:    "cloud",
+			Tags:        []string{"azure"},
+			DedupeKey:   "bulk-3",
+		},
+	})
+	if err != nil {
+		t.Fatalf("second BulkUpsert returned error: %v", err)
+	}
+	if inserted != 1 || duplicated != 1 {
+		t.Fatalf("unexpected second counts: inserted=%d duplicated=%d", inserted, duplicated)
+	}
+
+	updatedArticle, err := repo.GetByID(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("GetByID returned error: %v", err)
+	}
+	if updatedArticle == nil || updatedArticle.Title != "First title updated" || updatedArticle.Excerpt != "updated" {
+		t.Fatalf("unexpected updated article: %+v", updatedArticle)
+	}
+}

--- a/services/article-service/internal/repository/article_repository_integration_test.go
+++ b/services/article-service/internal/repository/article_repository_integration_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestArticleRepositoryListExportAndStatusUpdates(t *testing.T) {
+	// 検索条件、ページング、CSV export、状態更新が MySQL 実体で崩れないことを確認する。
 	db := testutil.OpenMySQLForTest(t)
 	testutil.ResetMySQLTables(t, db)
 
@@ -81,6 +82,8 @@ func TestArticleRepositoryListExportAndStatusUpdates(t *testing.T) {
 	isFavorite := true
 	from := time.Date(2026, 4, 9, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2026, 4, 13, 0, 0, 0, 0, time.UTC)
+
+	// 一覧は filter と sort を SQL で解決するため、返却件数と先頭行の両方を見る。
 	listResult, err := repo.List(context.Background(), domain.ListArticlesParams{
 		ArticleFilterParams: domain.ArticleFilterParams{
 			Query:         "Kubernetes",
@@ -104,6 +107,7 @@ func TestArticleRepositoryListExportAndStatusUpdates(t *testing.T) {
 		t.Fatalf("unexpected first item: %+v", got)
 	}
 
+	// CSV export は limit+1 件を読み、service 層が上限超過を判定できる前提を守る。
 	exported, err := repo.Export(context.Background(), domain.ExportArticlesParams{
 		ArticleFilterParams: domain.ArticleFilterParams{
 			SourceID:   sourceAID,
@@ -123,6 +127,7 @@ func TestArticleRepositoryListExportAndStatusUpdates(t *testing.T) {
 		t.Fatalf("unexpected export order: %+v", exported)
 	}
 
+	// 既読・お気に入り更新は更新後の最新行を再取得して返す契約を守る。
 	updatedRead, err := repo.UpdateReadStatus(context.Background(), articleA1ID, true)
 	if err != nil {
 		t.Fatalf("UpdateReadStatus returned error: %v", err)
@@ -139,6 +144,7 @@ func TestArticleRepositoryListExportAndStatusUpdates(t *testing.T) {
 		t.Fatalf("unexpected favorite-status update result: %+v", updatedFavorite)
 	}
 
+	// 更新対象が存在しない場合は not found 相当として nil を返す。
 	missing, err := repo.UpdateFavoriteStatus(context.Background(), 999999, true)
 	if err != nil {
 		t.Fatalf("unexpected missing update error: %v", err)
@@ -149,6 +155,7 @@ func TestArticleRepositoryListExportAndStatusUpdates(t *testing.T) {
 }
 
 func TestArticleRepositoryBulkUpsertCountsInsertedAndDuplicated(t *testing.T) {
+	// dedupe_key の unique 制約を使った insert / duplicate 判定が件数に反映されることを確認する。
 	db := testutil.OpenMySQLForTest(t)
 	testutil.ResetMySQLTables(t, db)
 
@@ -194,6 +201,7 @@ func TestArticleRepositoryBulkUpsertCountsInsertedAndDuplicated(t *testing.T) {
 		t.Fatalf("unexpected initial counts: inserted=%d duplicated=%d", inserted, duplicated)
 	}
 
+	// duplicate 側は件数だけでなく、更新列が実際に反映されることまで見る。
 	inserted, duplicated, err = repo.BulkUpsert(context.Background(), sourceID, []domain.Article{
 		{
 			Title:       "First title updated",

--- a/services/article-service/internal/repository/fetch_job_repository_integration_test.go
+++ b/services/article-service/internal/repository/fetch_job_repository_integration_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestFetchJobRepositoryCreateFinishAndList(t *testing.T) {
+	// fetch job の開始、完了、履歴一覧が source 単位で一貫して扱えることを確認する。
 	db := testutil.OpenMySQLForTest(t)
 	testutil.ResetMySQLTables(t, db)
 
@@ -37,6 +38,7 @@ func TestFetchJobRepositoryCreateFinishAndList(t *testing.T) {
 		t.Fatalf("unexpected created job: %+v", job)
 	}
 
+	// 完了時は counts と error_message を含めて更新され、再取得で確認できる必要がある。
 	errMsg := "collector timeout"
 	if err := repo.Finish(context.Background(), jobID, "failed", 12, 5, 7, &errMsg); err != nil {
 		t.Fatalf("Finish returned error: %v", err)
@@ -50,6 +52,7 @@ func TestFetchJobRepositoryCreateFinishAndList(t *testing.T) {
 		t.Fatalf("unexpected finished job: %+v", finished)
 	}
 
+	// 履歴一覧は started_at 降順が正本なので、新しい job が先頭に来ることを見る。
 	olderStart := time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC)
 	newerStart := time.Date(2026, 4, 11, 9, 0, 0, 0, time.UTC)
 	testutil.InsertFetchJob(t, db, domain.FetchJob{

--- a/services/article-service/internal/repository/fetch_job_repository_integration_test.go
+++ b/services/article-service/internal/repository/fetch_job_repository_integration_test.go
@@ -1,0 +1,87 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"tech-feed-hub/article-service/internal/domain"
+	"tech-feed-hub/article-service/internal/testutil"
+)
+
+func TestFetchJobRepositoryCreateFinishAndList(t *testing.T) {
+	db := testutil.OpenMySQLForTest(t)
+	testutil.ResetMySQLTables(t, db)
+
+	repo := NewFetchJobRepository(db)
+	sourceID := testutil.InsertSource(t, db, domain.Source{
+		Name:            "Fetch Source",
+		Type:            "rss",
+		FetchURL:        "https://example.com/fetch.xml",
+		FetchMethod:     "rss",
+		IntervalMinutes: 20,
+		DefaultCategory: "news",
+		IsEnabled:       true,
+	})
+
+	jobID, err := repo.Create(context.Background(), sourceID)
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	job, err := repo.GetByID(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("GetByID returned error: %v", err)
+	}
+	if job == nil || job.Status != "running" || job.SourceID != sourceID {
+		t.Fatalf("unexpected created job: %+v", job)
+	}
+
+	errMsg := "collector timeout"
+	if err := repo.Finish(context.Background(), jobID, "failed", 12, 5, 7, &errMsg); err != nil {
+		t.Fatalf("Finish returned error: %v", err)
+	}
+
+	finished, err := repo.GetByID(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("GetByID after finish returned error: %v", err)
+	}
+	if finished == nil || finished.FinishedAt == nil || finished.Status != "failed" || finished.ErrorMessage == nil || *finished.ErrorMessage != errMsg {
+		t.Fatalf("unexpected finished job: %+v", finished)
+	}
+
+	olderStart := time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC)
+	newerStart := time.Date(2026, 4, 11, 9, 0, 0, 0, time.UTC)
+	testutil.InsertFetchJob(t, db, domain.FetchJob{
+		SourceID:        sourceID,
+		StartedAt:       olderStart,
+		Status:          "success",
+		FetchedCount:    3,
+		InsertedCount:   2,
+		DuplicatedCount: 1,
+	})
+	testutil.InsertFetchJob(t, db, domain.FetchJob{
+		SourceID:        sourceID,
+		StartedAt:       newerStart,
+		Status:          "success",
+		FetchedCount:    4,
+		InsertedCount:   4,
+		DuplicatedCount: 0,
+	})
+
+	listed, err := repo.List(context.Background(), domain.ListFetchJobsParams{
+		SourceID: sourceID,
+		Status:   "success",
+		Page:     1,
+		PageSize: 1,
+	})
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if listed.Total != 2 || listed.TotalPages != 2 || len(listed.Items) != 1 {
+		t.Fatalf("unexpected list meta: %+v", listed)
+	}
+	if !listed.Items[0].StartedAt.Equal(newerStart) {
+		t.Fatalf("expected newest success job first, got %+v", listed.Items[0])
+	}
+}

--- a/services/article-service/internal/repository/source_repository_integration_test.go
+++ b/services/article-service/internal/repository/source_repository_integration_test.go
@@ -1,0 +1,140 @@
+package repository
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"tech-feed-hub/article-service/internal/domain"
+	"tech-feed-hub/article-service/internal/testutil"
+)
+
+func TestSourceRepositoryCRUDAndConstraints(t *testing.T) {
+	db := testutil.OpenMySQLForTest(t)
+	testutil.ResetMySQLTables(t, db)
+
+	repo := NewSourceRepository(db)
+
+	created, err := repo.Create(context.Background(), domain.Source{
+		Name:            "Kubernetes Blog",
+		Type:            "rss",
+		FetchURL:        "https://example.com/k8s.xml",
+		FetchMethod:     "rss",
+		IntervalMinutes: 60,
+		DefaultCategory: "k8s",
+		IsEnabled:       true,
+	})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if created == nil || created.ID < 1 || created.Name != "Kubernetes Blog" {
+		t.Fatalf("unexpected created source: %+v", created)
+	}
+
+	listed, err := repo.List(context.Background())
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(listed) != 1 || listed[0].ID != created.ID {
+		t.Fatalf("unexpected listed sources: %+v", listed)
+	}
+
+	updated, err := repo.Update(context.Background(), domain.Source{
+		ID:              created.ID,
+		Name:            "Kubernetes Official Blog",
+		Type:            "rss",
+		FetchURL:        "https://example.com/official.xml",
+		FetchMethod:     "rss",
+		IntervalMinutes: 30,
+		DefaultCategory: "platform",
+		IsEnabled:       false,
+	})
+	if err != nil {
+		t.Fatalf("Update returned error: %v", err)
+	}
+	if updated == nil || updated.Name != "Kubernetes Official Blog" || updated.IsEnabled {
+		t.Fatalf("unexpected updated source: %+v", updated)
+	}
+
+	lastError := "timeout"
+	if err := repo.UpdateFetchStatus(context.Background(), created.ID, "failed", &lastError); err != nil {
+		t.Fatalf("UpdateFetchStatus returned error: %v", err)
+	}
+	got, err := repo.GetByID(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("GetByID returned error: %v", err)
+	}
+	if got == nil || got.LastFetchStatus == nil || *got.LastFetchStatus != "failed" || got.LastErrorMsg == nil || *got.LastErrorMsg != "timeout" || got.LastFetchedAt == nil {
+		t.Fatalf("unexpected fetch status payload: %+v", got)
+	}
+
+	ensuredID, err := repo.EnsureSource(context.Background(), domain.Source{
+		Name:            got.Name,
+		Type:            "rss",
+		FetchURL:        "https://example.com/reconciled.xml",
+		FetchMethod:     "rss",
+		IntervalMinutes: 45,
+		DefaultCategory: "infra",
+	})
+	if err != nil {
+		t.Fatalf("EnsureSource returned error: %v", err)
+	}
+	if ensuredID != created.ID {
+		t.Fatalf("expected existing source id %d, got %d", created.ID, ensuredID)
+	}
+
+	duplicate, err := repo.Create(context.Background(), domain.Source{
+		Name:            got.Name,
+		Type:            "rss",
+		FetchURL:        "https://example.com/dup.xml",
+		FetchMethod:     "rss",
+		IntervalMinutes: 10,
+		DefaultCategory: "dup",
+		IsEnabled:       true,
+	})
+	if err == nil || duplicate != nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("expected duplicate error, got source=%+v err=%v", duplicate, err)
+	}
+
+	deleted, err := repo.Delete(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("Delete returned error: %v", err)
+	}
+	if !deleted {
+		t.Fatal("expected source to be deleted")
+	}
+}
+
+func TestSourceRepositoryDeleteReturnsReferencedError(t *testing.T) {
+	db := testutil.OpenMySQLForTest(t)
+	testutil.ResetMySQLTables(t, db)
+
+	repo := NewSourceRepository(db)
+	sourceID := testutil.InsertSource(t, db, domain.Source{
+		Name:            "Protected Source",
+		Type:            "rss",
+		FetchURL:        "https://example.com/protected.xml",
+		FetchMethod:     "rss",
+		IntervalMinutes: 60,
+		DefaultCategory: "ops",
+		IsEnabled:       true,
+	})
+
+	published := time.Date(2026, 4, 15, 10, 0, 0, 0, time.UTC)
+	testutil.InsertArticle(t, db, domain.Article{
+		Title:       "Dependent article",
+		URL:         "https://example.com/dependent",
+		SourceID:    sourceID,
+		PublishedAt: &published,
+		FetchedAt:   published,
+		Excerpt:     "dependent",
+		Category:    "ops",
+		DedupeKey:   "protected-1",
+	})
+
+	deleted, err := repo.Delete(context.Background(), sourceID)
+	if err == nil || deleted || !strings.Contains(err.Error(), "referenced") {
+		t.Fatalf("expected referenced delete error, got deleted=%t err=%v", deleted, err)
+	}
+}

--- a/services/article-service/internal/repository/source_repository_integration_test.go
+++ b/services/article-service/internal/repository/source_repository_integration_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestSourceRepositoryCRUDAndConstraints(t *testing.T) {
+	// source の CRUD と補助更新系が schema 制約込みで成立することを確認する。
 	db := testutil.OpenMySQLForTest(t)
 	testutil.ResetMySQLTables(t, db)
 
@@ -32,6 +33,7 @@ func TestSourceRepositoryCRUDAndConstraints(t *testing.T) {
 		t.Fatalf("unexpected created source: %+v", created)
 	}
 
+	// 一覧と単体取得が同じ正規形を返せることを確認する。
 	listed, err := repo.List(context.Background())
 	if err != nil {
 		t.Fatalf("List returned error: %v", err)
@@ -57,6 +59,7 @@ func TestSourceRepositoryCRUDAndConstraints(t *testing.T) {
 		t.Fatalf("unexpected updated source: %+v", updated)
 	}
 
+	// source 詳細画面で使う取得状態の更新列が DB に保存されることを見る。
 	lastError := "timeout"
 	if err := repo.UpdateFetchStatus(context.Background(), created.ID, "failed", &lastError); err != nil {
 		t.Fatalf("UpdateFetchStatus returned error: %v", err)
@@ -69,6 +72,7 @@ func TestSourceRepositoryCRUDAndConstraints(t *testing.T) {
 		t.Fatalf("unexpected fetch status payload: %+v", got)
 	}
 
+	// EnsureSource は既存行を重複作成せず、同じ ID を返す必要がある。
 	ensuredID, err := repo.EnsureSource(context.Background(), domain.Source{
 		Name:            got.Name,
 		Type:            "rss",
@@ -84,6 +88,7 @@ func TestSourceRepositoryCRUDAndConstraints(t *testing.T) {
 		t.Fatalf("expected existing source id %d, got %d", created.ID, ensuredID)
 	}
 
+	// name の unique 制約違反は service 層で 409 に変換できるエラー表現へ寄せる。
 	duplicate, err := repo.Create(context.Background(), domain.Source{
 		Name:            got.Name,
 		Type:            "rss",
@@ -97,6 +102,7 @@ func TestSourceRepositoryCRUDAndConstraints(t *testing.T) {
 		t.Fatalf("expected duplicate error, got source=%+v err=%v", duplicate, err)
 	}
 
+	// 参照がなければ削除は成功する。
 	deleted, err := repo.Delete(context.Background(), created.ID)
 	if err != nil {
 		t.Fatalf("Delete returned error: %v", err)
@@ -107,6 +113,7 @@ func TestSourceRepositoryCRUDAndConstraints(t *testing.T) {
 }
 
 func TestSourceRepositoryDeleteReturnsReferencedError(t *testing.T) {
+	// article 参照中の source は外部キー制約により削除不可であることを確認する。
 	db := testutil.OpenMySQLForTest(t)
 	testutil.ResetMySQLTables(t, db)
 

--- a/services/article-service/internal/testutil/mysql.go
+++ b/services/article-service/internal/testutil/mysql.go
@@ -1,0 +1,214 @@
+package testutil
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	"tech-feed-hub/article-service/internal/domain"
+)
+
+var schemaInit sync.Once
+
+func OpenMySQLForTest(t *testing.T) *sql.DB {
+	t.Helper()
+
+	if os.Getenv("ARTICLE_SERVICE_RUN_INTEGRATION") != "1" {
+		t.Skip("skip mysql integration test; set ARTICLE_SERVICE_RUN_INTEGRATION=1 to enable")
+	}
+
+	dsn := strings.TrimSpace(os.Getenv("ARTICLE_SERVICE_TEST_MYSQL_DSN"))
+	if dsn == "" {
+		dsn = strings.TrimSpace(os.Getenv("MYSQL_DSN"))
+	}
+	if dsn == "" {
+		dsn = "app_user:app_password@tcp(127.0.0.1:3306)/tech_feed_hub?parseTime=true&multiStatements=true"
+	}
+
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open mysql: %v", err)
+	}
+	db.SetConnMaxLifetime(time.Minute)
+	db.SetMaxOpenConns(5)
+	db.SetMaxIdleConns(5)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		t.Skipf("skip mysql integration test; mysql unavailable for dsn %q: %v", dsn, err)
+	}
+
+	schemaInit.Do(func() {
+		if err := applySchema(ctx, db); err != nil {
+			t.Fatalf("apply schema: %v", err)
+		}
+	})
+
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("close mysql: %v", err)
+		}
+	})
+
+	return db
+}
+
+func ResetMySQLTables(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	stmts := []string{
+		"SET FOREIGN_KEY_CHECKS = 0",
+		"TRUNCATE TABLE notifications",
+		"TRUNCATE TABLE fetch_jobs",
+		"TRUNCATE TABLE articles",
+		"TRUNCATE TABLE sources",
+		"SET FOREIGN_KEY_CHECKS = 1",
+	}
+	for _, stmt := range stmts {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			t.Fatalf("reset tables with %q: %v", stmt, err)
+		}
+	}
+}
+
+func InsertSource(t *testing.T, db *sql.DB, source domain.Source) int64 {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := db.ExecContext(ctx, `
+		INSERT INTO sources (name, type, fetch_url, fetch_method, interval_minutes, default_category, is_enabled, last_fetched_at, last_fetch_status, last_error_message)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		source.Name,
+		source.Type,
+		source.FetchURL,
+		source.FetchMethod,
+		source.IntervalMinutes,
+		source.DefaultCategory,
+		source.IsEnabled,
+		source.LastFetchedAt,
+		source.LastFetchStatus,
+		source.LastErrorMsg,
+	)
+	if err != nil {
+		t.Fatalf("insert source: %v", err)
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("source last insert id: %v", err)
+	}
+	return id
+}
+
+func InsertArticle(t *testing.T, db *sql.DB, article domain.Article) int64 {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tags := "[]"
+	if len(article.Tags) > 0 {
+		quoted := make([]string, 0, len(article.Tags))
+		for _, tag := range article.Tags {
+			quoted = append(quoted, fmt.Sprintf("%q", tag))
+		}
+		tags = "[" + strings.Join(quoted, ",") + "]"
+	}
+
+	result, err := db.ExecContext(ctx, `
+		INSERT INTO articles (title, url, source_id, published_at, fetched_at, excerpt, category, tags, is_read, is_favorite, dedupe_key)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		article.Title,
+		article.URL,
+		article.SourceID,
+		article.PublishedAt,
+		article.FetchedAt,
+		article.Excerpt,
+		article.Category,
+		tags,
+		article.IsRead,
+		article.IsFavorite,
+		article.DedupeKey,
+	)
+	if err != nil {
+		t.Fatalf("insert article: %v", err)
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("article last insert id: %v", err)
+	}
+	return id
+}
+
+func InsertFetchJob(t *testing.T, db *sql.DB, job domain.FetchJob) int64 {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := db.ExecContext(ctx, `
+		INSERT INTO fetch_jobs (source_id, started_at, finished_at, status, fetched_count, inserted_count, duplicated_count, error_message)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		job.SourceID,
+		job.StartedAt,
+		job.FinishedAt,
+		job.Status,
+		job.FetchedCount,
+		job.InsertedCount,
+		job.DuplicatedCount,
+		job.ErrorMessage,
+	)
+	if err != nil {
+		t.Fatalf("insert fetch job: %v", err)
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("fetch job last insert id: %v", err)
+	}
+	return id
+}
+
+func applySchema(ctx context.Context, db *sql.DB) error {
+	schemaPath := filepath.Join(repoRootFromCaller(), "deployments/compose/mysql/init/001_schema.sql")
+	content, err := os.ReadFile(schemaPath)
+	if err != nil {
+		return fmt.Errorf("read schema file: %w", err)
+	}
+
+	for _, stmt := range strings.Split(string(content), ";") {
+		stmt = strings.TrimSpace(stmt)
+		if stmt == "" {
+			continue
+		}
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("exec schema statement: %w", err)
+		}
+	}
+	return nil
+}
+
+func repoRootFromCaller() string {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("resolve caller path")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "..", "..", ".."))
+}


### PR DESCRIPTION
## 概要

- article-service に MySQL ベースの integration test utility を追加
- repository / handler の integration test を追加
- integration test 実行導線と runbook を追加

## 背景 / 目的

- issue #29 の対応として、service の stub test だけでは拾えない DB / handler 境界の回帰を検知できるようにするため
- article-service の検索、CSV、source 管理、fetch job は schema / query / HTTP status のずれに弱く、MySQL 実体を使った検証が必要なため

## 変更内容

- `services/article-service/internal/testutil/mysql.go` を追加し、schema 適用・テーブル初期化・seed 挿入を共通化
- `services/article-service/internal/repository/*_integration_test.go` を追加し、articles / sources / fetch_jobs の実 DB テストを追加
- `services/article-service/internal/httpapi/router_integration_test.go` を追加し、400 / 404 / 409 / 500 と CSV endpoint を検証
- `services/article-service/internal/httpapi/router.go` で `GET /articles/:id` と `/internal/ingest` の error mapping を `writeServiceError` に統一
- `Makefile` に `test-article-integration` を追加し、`docs/runbook.md` に実行手順を追記

## 影響範囲

- frontend
- api-gateway
- collector-service
- article-service
- notification-service
- infra
- docs

## 検証

- [x] `go test ./...`
- [ ] `npm run build`
- [ ] `docker compose config -q`
- [x] その他:
- `ARTICLE_SERVICE_RUN_INTEGRATION=1 GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...` を実行
- sandbox 制約により MySQL 接続ができず、integration test 本体は skip になることを確認

## API / DB / Infra への影響

- [ ] API を変更した
- [ ] DB schema を変更した
- [ ] Compose を変更した
- [ ] Kubernetes / Helm を変更した
- [x] 大きな影響はない

## ドキュメント

- [ ] 必要に応じて `RULES.md` を更新した
- [x] 関連する `docs/` を更新した
- [ ] ドキュメント更新は不要

## リスク / 注意点

- integration test の実 DB 実行確認は、MySQL が利用可能な環境で別途必要
- `ARTICLE_SERVICE_RUN_INTEGRATION=1` を付けない通常の `go test` では integration test は実行されない

## 補足

- issue #29 対応
- commit: `f64d520`