### PR TITLE
notification / source 管理周辺の回帰テストを追加

### DIFF
--- a/frontend/src/ui/NotificationListPage.test.tsx
+++ b/frontend/src/ui/NotificationListPage.test.tsx
@@ -1,0 +1,164 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { NotificationListPage } from "./NotificationListPage";
+import { renderWithProviders } from "../test/render";
+import { server } from "../test/setup";
+
+type NotificationItem = {
+  id: number;
+  event_id: string;
+  event_type: "article.ingested" | "collector.fetch.failed";
+  level: "info" | "error";
+  title: string;
+  body: string;
+  source_id: number | null;
+  fetch_job_id: number | null;
+  is_read: boolean;
+  created_at: string;
+  read_at: string | null;
+};
+
+function buildNotification(id: number, isRead: boolean): NotificationItem {
+  return {
+    id,
+    event_id: `evt-${id}`,
+    event_type: id % 2 === 0 ? "collector.fetch.failed" : "article.ingested",
+    level: id % 2 === 0 ? "error" : "info",
+    title: `Notification ${id}`,
+    body: `Body ${id}`,
+    source_id: 3,
+    fetch_job_id: 10 + id,
+    is_read: isRead,
+    created_at: new Date(Date.UTC(2026, 3, id, 0, 0, 0)).toISOString(),
+    read_at: isRead ? new Date(Date.UTC(2026, 3, id, 1, 0, 0)).toISOString() : null,
+  };
+}
+
+describe("NotificationListPage", () => {
+  it("loads notifications, applies filters, and paginates", async () => {
+    const user = userEvent.setup();
+    const requestLog: string[] = [];
+    const notifications = Array.from({ length: 11 }, (_, index) => buildNotification(11 - index, (11 - index) % 2 === 0));
+
+    server.use(
+      http.get("http://localhost:8080/api/v1/notifications", ({ request }) => {
+        const url = new URL(request.url);
+        const isRead = url.searchParams.get("is_read");
+        const page = Number(url.searchParams.get("page") ?? "1");
+        const pageSize = Number(url.searchParams.get("page_size") ?? "10");
+        requestLog.push(url.search);
+
+        const filtered =
+          isRead == null ? notifications : notifications.filter((item) => item.is_read === (isRead === "true"));
+        const start = (page - 1) * pageSize;
+        const items = filtered.slice(start, start + pageSize);
+
+        return HttpResponse.json({
+          items,
+          total: filtered.length,
+          page,
+          page_size: pageSize,
+          total_pages: Math.max(Math.ceil(filtered.length / pageSize), 1),
+        });
+      }),
+    );
+
+    renderWithProviders(<NotificationListPage />);
+
+    expect(await screen.findByText("Notification 11")).toBeInTheDocument();
+    expect(requestLog[0]).toContain("page=1");
+    expect(requestLog[0]).toContain("page_size=10");
+    expect(screen.getByText("11 notifications / page 1")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Next" }));
+    expect(await screen.findByText("Notification 1")).toBeInTheDocument();
+    expect(requestLog.at(-1)).toContain("page=2");
+
+    await user.selectOptions(screen.getByLabelText("Status"), "unread");
+    expect(await screen.findByText("Notification 11")).toBeInTheDocument();
+
+    // page 2 から filter を変えたとき page 1 に戻ることを query で確認する。
+    await waitFor(() => expect(requestLog.at(-1)).toContain("is_read=false"));
+    expect(requestLog.at(-1)).toContain("page=1");
+  });
+
+  it("updates read status and makes the item visible under the read filter", async () => {
+    const user = userEvent.setup();
+    const requestLog: string[] = [];
+    let notifications = [buildNotification(1, false)];
+
+    server.use(
+      http.get("http://localhost:8080/api/v1/notifications", ({ request }) => {
+        const url = new URL(request.url);
+        requestLog.push(url.search);
+        const isRead = url.searchParams.get("is_read");
+        const filtered =
+          isRead == null ? notifications : notifications.filter((item) => item.is_read === (isRead === "true"));
+        return HttpResponse.json({
+          items: filtered,
+          total: filtered.length,
+          page: 1,
+          page_size: 10,
+          total_pages: 1,
+        });
+      }),
+      http.patch("http://localhost:8080/api/v1/notifications/1/read-status", async ({ request }) => {
+        const body = (await request.json()) as { is_read: boolean };
+        notifications = notifications.map((item) =>
+          item.id === 1
+            ? {
+                ...item,
+                is_read: body.is_read,
+                read_at: body.is_read ? new Date(Date.UTC(2026, 3, 18, 12, 0, 0)).toISOString() : null,
+              }
+            : item,
+        );
+        return HttpResponse.json(notifications[0]);
+      }),
+    );
+
+    renderWithProviders(<NotificationListPage />);
+
+    expect(await screen.findByText("Notification 1")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "既読にする" }));
+
+    expect(await screen.findByText("既読")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "未読に戻す" })).toBeInTheDocument();
+
+    // 一覧内の局所更新だけでなく、read filter 側にも移動できる状態になっていることを確認する。
+    await user.selectOptions(screen.getByLabelText("Status"), "read");
+    expect(await screen.findByText("Notification 1")).toBeInTheDocument();
+    expect(requestLog.at(-1)).toContain("is_read=true");
+  });
+
+  it("shows an API error message", async () => {
+    server.use(
+      http.get("http://localhost:8080/api/v1/notifications", () =>
+        HttpResponse.json({ error: "notification api failed" }, { status: 500 }),
+      ),
+    );
+
+    renderWithProviders(<NotificationListPage />);
+
+    expect(await screen.findByText("notification api failed")).toBeInTheDocument();
+  });
+
+  it("shows the empty state when no notifications match the filter", async () => {
+    server.use(
+      http.get("http://localhost:8080/api/v1/notifications", () =>
+        HttpResponse.json({
+          items: [],
+          total: 0,
+          page: 1,
+          page_size: 10,
+          total_pages: 1,
+        }),
+      ),
+    );
+
+    renderWithProviders(<NotificationListPage />);
+
+    expect(await screen.findByText("No notifications matched the current filter.")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/ui/SourceDetailPage.test.tsx
+++ b/frontend/src/ui/SourceDetailPage.test.tsx
@@ -1,0 +1,166 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { SourceDetailPage } from "./SourceDetailPage";
+import { renderWithProviders } from "../test/render";
+import { server } from "../test/setup";
+
+type SourceItem = {
+  id: number;
+  name: string;
+  type: string;
+  fetch_url: string;
+  fetch_method: string;
+  interval_minutes: number;
+  default_category: string;
+  is_enabled: boolean;
+  last_fetched_at: string | null;
+  last_fetch_status: string | null;
+  last_error_message: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type FetchJobItem = {
+  id: number;
+  source_id: number;
+  started_at: string;
+  finished_at: string | null;
+  status: "running" | "success" | "failed";
+  fetched_count: number;
+  inserted_count: number;
+  duplicated_count: number;
+  error_message: string | null;
+};
+
+function buildSource(): SourceItem {
+  return {
+    id: 1,
+    name: "Kubernetes Blog",
+    type: "rss",
+    fetch_url: "https://example.com/kubernetes.xml",
+    fetch_method: "rss",
+    interval_minutes: 60,
+    default_category: "kubernetes",
+    is_enabled: true,
+    last_fetched_at: "2026-04-18T00:00:00Z",
+    last_fetch_status: "success",
+    last_error_message: null,
+    created_at: "2026-04-18T00:00:00Z",
+    updated_at: "2026-04-18T00:00:00Z",
+  };
+}
+
+function buildJob(id: number, status: "running" | "success" | "failed", finishedAt: string | null, errorMessage: string | null): FetchJobItem {
+  return {
+    id,
+    source_id: 1,
+    started_at: new Date(Date.UTC(2026, 3, id, 0, 0, 0)).toISOString(),
+    finished_at: finishedAt,
+    status,
+    fetched_count: 10,
+    inserted_count: 7,
+    duplicated_count: 3,
+    error_message: errorMessage,
+  };
+}
+
+describe("SourceDetailPage", () => {
+  it("shows an error for an invalid source id", () => {
+    renderWithProviders(<SourceDetailPage />, { path: "/sources/:id", route: "/sources/abc" });
+    expect(screen.getByText("Invalid source id")).toBeInTheDocument();
+  });
+
+  it("loads source details, applies job filters, and paginates", async () => {
+    const user = userEvent.setup();
+    const requestLog: string[] = [];
+    const source = buildSource();
+    const jobs = [buildJob(11, "running", null, null), ...Array.from({ length: 10 }, (_, index) => buildJob(10 - index, index % 2 === 0 ? "failed" : "success", new Date(Date.UTC(2026, 3, 10 - index, 1, 0, 0)).toISOString(), index % 2 === 0 ? "collector failed" : null))];
+
+    server.use(
+      http.get("http://localhost:8080/api/v1/sources/1", () => HttpResponse.json(source)),
+      http.get("http://localhost:8080/api/v1/fetch-jobs", ({ request }) => {
+        const url = new URL(request.url);
+        const status = url.searchParams.get("status");
+        const page = Number(url.searchParams.get("page") ?? "1");
+        const pageSize = Number(url.searchParams.get("page_size") ?? "10");
+        requestLog.push(url.search);
+
+        const filtered = status == null ? jobs : jobs.filter((job) => job.status === status);
+        const start = (page - 1) * pageSize;
+        const items = filtered.slice(start, start + pageSize);
+
+        return HttpResponse.json({
+          items,
+          total: filtered.length,
+          page,
+          page_size: pageSize,
+          total_pages: Math.max(Math.ceil(filtered.length / pageSize), 1),
+        });
+      }),
+    );
+
+    renderWithProviders(<SourceDetailPage />, { path: "/sources/:id", route: "/sources/1" });
+
+    expect(await screen.findByRole("heading", { name: "Kubernetes Blog" })).toBeInTheDocument();
+    expect(screen.getByText("Source Overview")).toBeInTheDocument();
+    expect(screen.getByText("Fetch Job History")).toBeInTheDocument();
+    const runningJobCard = screen.getByText("Job #11").closest("article")!;
+    expect(within(runningJobCard).getByText(/not finished/)).toBeInTheDocument();
+    expect(requestLog[0]).toContain("source_id=1");
+    expect(requestLog[0]).toContain("page=1");
+    expect(requestLog[0]).toContain("page_size=10");
+
+    await user.click(screen.getByRole("button", { name: "Next" }));
+    expect(await screen.findByText("Job #1")).toBeInTheDocument();
+
+    await user.selectOptions(screen.getByLabelText("Status"), "failed");
+    // failed filter では複数件が残るため、単一カードではなく filter 後の一覧全体を確認する。
+    expect((await screen.findAllByText("collector failed")).length).toBeGreaterThan(0);
+
+    // page 2 から status filter を変えたとき page 1 に戻ることを request query で固定する。
+    await waitFor(() => expect(requestLog.at(-1)).toContain("status=failed"));
+    expect(requestLog.at(-1)).toContain("page=1");
+  });
+
+  it("shows a source API error", async () => {
+    server.use(
+      http.get("http://localhost:8080/api/v1/sources/1", () =>
+        HttpResponse.json({ error: "source detail failed" }, { status: 500 }),
+      ),
+      http.get("http://localhost:8080/api/v1/fetch-jobs", () =>
+        HttpResponse.json({ items: [], total: 0, page: 1, page_size: 10, total_pages: 1 }),
+      ),
+    );
+
+    renderWithProviders(<SourceDetailPage />, { path: "/sources/:id", route: "/sources/1" });
+
+    expect(await screen.findByText("source detail failed")).toBeInTheDocument();
+  });
+
+  it("shows a fetch jobs API error", async () => {
+    server.use(
+      http.get("http://localhost:8080/api/v1/sources/1", () => HttpResponse.json(buildSource())),
+      http.get("http://localhost:8080/api/v1/fetch-jobs", () =>
+        HttpResponse.json({ error: "fetch jobs failed" }, { status: 500 }),
+      ),
+    );
+
+    renderWithProviders(<SourceDetailPage />, { path: "/sources/:id", route: "/sources/1" });
+
+    expect(await screen.findByText("fetch jobs failed")).toBeInTheDocument();
+  });
+
+  it("shows the empty job state", async () => {
+    server.use(
+      http.get("http://localhost:8080/api/v1/sources/1", () => HttpResponse.json(buildSource())),
+      http.get("http://localhost:8080/api/v1/fetch-jobs", () =>
+        HttpResponse.json({ items: [], total: 0, page: 1, page_size: 10, total_pages: 1 }),
+      ),
+    );
+
+    renderWithProviders(<SourceDetailPage />, { path: "/sources/:id", route: "/sources/1" });
+
+    expect(await screen.findByText("No fetch jobs matched the current filter.")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/ui/SourceManagementPage.test.tsx
+++ b/frontend/src/ui/SourceManagementPage.test.tsx
@@ -1,0 +1,233 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { SourceManagementPage } from "./SourceManagementPage";
+import { renderWithProviders } from "../test/render";
+import { server } from "../test/setup";
+
+type SourceItem = {
+  id: number;
+  name: string;
+  type: string;
+  fetch_url: string;
+  fetch_method: string;
+  interval_minutes: number;
+  default_category: string;
+  is_enabled: boolean;
+  last_fetched_at: string | null;
+  last_fetch_status: string | null;
+  last_error_message: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+function buildSource(overrides: Partial<SourceItem> = {}): SourceItem {
+  return {
+    id: 1,
+    name: "Kubernetes Blog",
+    type: "rss",
+    fetch_url: "https://example.com/kubernetes.xml",
+    fetch_method: "rss",
+    interval_minutes: 60,
+    default_category: "kubernetes",
+    is_enabled: true,
+    last_fetched_at: "2026-04-18T00:00:00Z",
+    last_fetch_status: "success",
+    last_error_message: null,
+    created_at: "2026-04-18T00:00:00Z",
+    updated_at: "2026-04-18T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("SourceManagementPage", () => {
+  it("populates the edit form from the selected source and resets to create mode", async () => {
+    const user = userEvent.setup();
+    const sources = [buildSource()];
+
+    server.use(
+      http.get("http://localhost:8080/api/v1/sources", () => HttpResponse.json({ items: sources })),
+    );
+
+    renderWithProviders(<SourceManagementPage />);
+
+    expect(await screen.findByText("Kubernetes Blog")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Edit Source" }));
+
+    expect(screen.getByRole("heading", { name: "Edit: Kubernetes Blog" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Name")).toHaveValue("Kubernetes Blog");
+    expect(screen.getByLabelText("Fetch URL")).toHaveValue("https://example.com/kubernetes.xml");
+
+    await user.click(screen.getByRole("button", { name: "Reset" }));
+    expect(screen.getByRole("heading", { name: "Create Source" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Name")).toHaveValue("");
+
+    await user.click(screen.getByRole("button", { name: "Edit Source" }));
+    await user.click(screen.getByRole("button", { name: "New Source" }));
+    expect(screen.getByRole("heading", { name: "Create Source" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Name")).toHaveValue("");
+  });
+
+  it("shows validation errors before submitting", async () => {
+    const user = userEvent.setup();
+    let createCalls = 0;
+
+    server.use(
+      http.get("http://localhost:8080/api/v1/sources", () => HttpResponse.json({ items: [] })),
+      http.post("http://localhost:8080/api/v1/sources", () => {
+        createCalls += 1;
+        return HttpResponse.json(buildSource({ id: 2 }));
+      }),
+    );
+
+    renderWithProviders(<SourceManagementPage />);
+
+    expect(await screen.findByText("0 sources")).toBeInTheDocument();
+    await user.type(screen.getByLabelText("Name"), "   ");
+    await user.type(screen.getByLabelText("Fetch URL"), "not-a-url");
+    await user.type(screen.getByLabelText("Default Category"), "   ");
+    await user.click(screen.getByRole("button", { name: "Create Source" }));
+
+    // trim 後に空になる入力を使い、zod validation が submit を止めることを確認する。
+    expect(await screen.findByText("name is required")).toBeInTheDocument();
+    expect(screen.getByText("fetch_url must be a valid URL")).toBeInTheDocument();
+    expect(screen.getByText("default_category is required")).toBeInTheDocument();
+    expect(createCalls).toBe(0);
+  });
+
+  it("submits trimmed payloads for create and edit", async () => {
+    const user = userEvent.setup();
+    let sources = [buildSource()];
+    let createdPayload: Record<string, unknown> | undefined;
+    let updatedPayload: Record<string, unknown> | undefined;
+
+    server.use(
+      http.get("http://localhost:8080/api/v1/sources", () => HttpResponse.json({ items: sources })),
+      http.post("http://localhost:8080/api/v1/sources", async ({ request }) => {
+        createdPayload = (await request.json()) as Record<string, unknown>;
+        const created = buildSource({
+          id: 2,
+          name: String(createdPayload.name),
+          fetch_url: String(createdPayload.fetch_url),
+          interval_minutes: Number(createdPayload.interval_minutes),
+          default_category: String(createdPayload.default_category),
+          is_enabled: Boolean(createdPayload.is_enabled),
+        });
+        sources = [...sources, created];
+        return HttpResponse.json(created);
+      }),
+      http.patch("http://localhost:8080/api/v1/sources/:id", async ({ params, request }) => {
+        updatedPayload = (await request.json()) as Record<string, unknown>;
+        const id = Number(params.id);
+        const updated = buildSource({
+          id,
+          name: String(updatedPayload.name),
+          fetch_url: String(updatedPayload.fetch_url),
+          interval_minutes: Number(updatedPayload.interval_minutes),
+          default_category: String(updatedPayload.default_category),
+          is_enabled: Boolean(updatedPayload.is_enabled),
+        });
+        sources = sources.map((source) => (source.id === id ? updated : source));
+        return HttpResponse.json(updated);
+      }),
+    );
+
+    renderWithProviders(<SourceManagementPage />);
+    expect(await screen.findByText("Kubernetes Blog")).toBeInTheDocument();
+
+    await user.clear(screen.getByLabelText("Name"));
+    await user.type(screen.getByLabelText("Name"), "  New Feed  ");
+    await user.clear(screen.getByLabelText("Fetch URL"));
+    await user.type(screen.getByLabelText("Fetch URL"), "  https://example.com/new.xml  ");
+    await user.clear(screen.getByLabelText("Default Category"));
+    await user.type(screen.getByLabelText("Default Category"), "  platform  ");
+    await user.click(screen.getByRole("button", { name: "Create Source" }));
+
+    // create / edit どちらも form 値を trim して payload に乗せる現在仕様を固定する。
+    await waitFor(() =>
+      expect(createdPayload).toMatchObject({
+        name: "New Feed",
+        fetch_url: "https://example.com/new.xml",
+        default_category: "platform",
+      }),
+    );
+    expect(await screen.findByRole("heading", { name: "Edit: New Feed" })).toBeInTheDocument();
+
+    const sourceCards = screen.getAllByText("Edit Source");
+    await user.click(sourceCards[0]);
+    await user.clear(screen.getByLabelText("Name"));
+    await user.type(screen.getByLabelText("Name"), "  Kubernetes Blog Updated  ");
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() =>
+      expect(updatedPayload).toMatchObject({
+        name: "Kubernetes Blog Updated",
+      }),
+    );
+  });
+
+  it("toggles source enable state with the full update payload", async () => {
+    const user = userEvent.setup();
+    let sources = [buildSource()];
+    let togglePayload: Record<string, unknown> | undefined;
+
+    server.use(
+      http.get("http://localhost:8080/api/v1/sources", () => HttpResponse.json({ items: sources })),
+      http.patch("http://localhost:8080/api/v1/sources/1", async ({ request }) => {
+        togglePayload = (await request.json()) as Record<string, unknown>;
+        sources = [buildSource({ is_enabled: false })];
+        return HttpResponse.json(sources[0]);
+      }),
+    );
+
+    renderWithProviders(<SourceManagementPage />);
+
+    const sourceCard = await screen.findByText("Kubernetes Blog");
+    await user.click(within(sourceCard.closest("article")!).getByRole("button", { name: "Enabled" }));
+
+    // toggle 専用 API ではなく完全更新 API を使うため、他フィールドが保持された payload になる。
+    await waitFor(() =>
+      expect(togglePayload).toEqual({
+        name: "Kubernetes Blog",
+        type: "rss",
+        fetch_url: "https://example.com/kubernetes.xml",
+        fetch_method: "rss",
+        interval_minutes: 60,
+        default_category: "kubernetes",
+        is_enabled: false,
+      }),
+    );
+    expect(await screen.findByRole("button", { name: "Disabled" })).toBeInTheDocument();
+  });
+
+  it("shows list and toggle API errors", async () => {
+    const user = userEvent.setup();
+
+    server.use(
+      http.get("http://localhost:8080/api/v1/sources", () =>
+        HttpResponse.json({ items: [buildSource()] }),
+      ),
+      http.patch("http://localhost:8080/api/v1/sources/1", () =>
+        HttpResponse.json({ error: "toggle failed" }, { status: 500 }),
+      ),
+    );
+
+    renderWithProviders(<SourceManagementPage />);
+
+    const sourceCard = await screen.findByText("Kubernetes Blog");
+    await user.click(within(sourceCard.closest("article")!).getByRole("button", { name: "Enabled" }));
+    expect(await screen.findByText("toggle failed")).toBeInTheDocument();
+  });
+
+  it("shows an error when the source list cannot be loaded", async () => {
+    server.use(
+      http.get("http://localhost:8080/api/v1/sources", () =>
+        HttpResponse.json({ error: "source list failed" }, { status: 500 }),
+      ),
+    );
+
+    renderWithProviders(<SourceManagementPage />);
+
+    expect(await screen.findByText("source list failed")).toBeInTheDocument();
+  });
+});

--- a/services/notification-service/internal/httpapi/router_integration_test.go
+++ b/services/notification-service/internal/httpapi/router_integration_test.go
@@ -1,0 +1,142 @@
+package httpapi
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"tech-feed-hub/notification-service/internal/domain"
+	"tech-feed-hub/notification-service/internal/repository"
+	"tech-feed-hub/notification-service/internal/service"
+	"tech-feed-hub/notification-service/internal/testutil"
+)
+
+func TestRouterNotificationEndpoints(t *testing.T) {
+	// 通知一覧と read-status 更新の 200/400/404 を handler 境界でまとめて確認する。
+	db, router := newIntegrationRouter(t)
+
+	sourceID := testutil.InsertSource(t, db, "Router Source")
+	startedAt := time.Date(2026, 4, 18, 8, 0, 0, 0, time.UTC)
+	finishedAt := startedAt.Add(5 * time.Minute)
+	fetchJobID := testutil.InsertFetchJob(t, db, sourceID, "failed", startedAt, &finishedAt)
+
+	notificationID := testutil.InsertNotification(t, db, domain.Notification{
+		EventID:    "evt-router-1",
+		EventType:  "collector.fetch.failed",
+		Level:      "error",
+		Title:      "Collector fetch failed",
+		Body:       "fetch rss status=502",
+		SourceID:   &sourceID,
+		FetchJobID: &fetchJobID,
+		IsRead:     false,
+		CreatedAt:  time.Date(2026, 4, 18, 9, 0, 0, 0, time.UTC),
+	})
+	readAt := time.Date(2026, 4, 18, 10, 0, 0, 0, time.UTC)
+	testutil.InsertNotification(t, db, domain.Notification{
+		EventID:    "evt-router-2",
+		EventType:  "article.ingested",
+		Level:      "info",
+		Title:      "Article ingested",
+		Body:       "new article",
+		SourceID:   &sourceID,
+		FetchJobID: &fetchJobID,
+		IsRead:     true,
+		CreatedAt:  time.Date(2026, 4, 18, 10, 0, 0, 0, time.UTC),
+		ReadAt:     &readAt,
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/notifications?is_read=false&page=1&page_size=1", nil)
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for notifications list, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var listResp domain.ListNotificationsResult
+	if err := json.Unmarshal(rec.Body.Bytes(), &listResp); err != nil {
+		t.Fatalf("unmarshal notifications list: %v", err)
+	}
+	if listResp.Total != 1 || len(listResp.Items) != 1 || listResp.Items[0].ID != notificationID {
+		t.Fatalf("unexpected notifications response: %+v", listResp)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/notifications?is_read=bad", nil)
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid bool query, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/notifications?page_size=101", nil)
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid page_size, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPatch, "/api/v1/notifications/"+int64String(notificationID)+"/read-status", strings.NewReader(`{"is_read":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for read-status update, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var updated domain.Notification
+	if err := json.Unmarshal(rec.Body.Bytes(), &updated); err != nil {
+		t.Fatalf("unmarshal updated notification: %v", err)
+	}
+	if !updated.IsRead || updated.ReadAt == nil {
+		t.Fatalf("expected read notification with read_at, got %+v", updated)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPatch, "/api/v1/notifications/bad/read-status", strings.NewReader(`{"is_read":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid id, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPatch, "/api/v1/notifications/999999/read-status", strings.NewReader(`{"is_read":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing notification, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRouterNotificationEndpointsReturnServerErrorOnDBFailure(t *testing.T) {
+	// DB 障害時は service / repository error を 500 として返す。
+	db, router := newIntegrationRouter(t)
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db for 500 test: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/notifications", nil)
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 after db close, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func newIntegrationRouter(t *testing.T) (*sql.DB, http.Handler) {
+	t.Helper()
+
+	db := testutil.OpenMySQLForTest(t)
+	testutil.ResetMySQLTables(t, db)
+
+	notificationRepo := repository.NewNotificationRepository(db)
+	notificationService := service.NewNotificationService(notificationRepo)
+
+	return db, NewRouter(db, notificationService)
+}
+
+func int64String(value int64) string {
+	return strconv.FormatInt(value, 10)
+}

--- a/services/notification-service/internal/repository/notification_repository_integration_test.go
+++ b/services/notification-service/internal/repository/notification_repository_integration_test.go
@@ -1,0 +1,112 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"tech-feed-hub/notification-service/internal/domain"
+	"tech-feed-hub/notification-service/internal/testutil"
+)
+
+func TestNotificationRepositoryListAndReadStatus(t *testing.T) {
+	// 通知一覧の filter / paging と read-status 更新時の read_at 契約を MySQL 実体で固定する。
+	db := testutil.OpenMySQLForTest(t)
+	testutil.ResetMySQLTables(t, db)
+
+	repo := NewNotificationRepository(db)
+
+	sourceID := testutil.InsertSource(t, db, "Notification Source")
+	startedAt := time.Date(2026, 4, 18, 8, 0, 0, 0, time.UTC)
+	finishedAt := startedAt.Add(5 * time.Minute)
+	fetchJobID := testutil.InsertFetchJob(t, db, sourceID, "success", startedAt, &finishedAt)
+
+	readAt := time.Date(2026, 4, 18, 10, 30, 0, 0, time.UTC)
+	olderCreatedAt := time.Date(2026, 4, 18, 9, 0, 0, 0, time.UTC)
+	newerCreatedAt := olderCreatedAt.Add(time.Hour)
+
+	olderID := testutil.InsertNotification(t, db, domain.Notification{
+		EventID:    "evt-older",
+		EventType:  "collector.fetch.failed",
+		Level:      "error",
+		Title:      "Older notification",
+		Body:       "older body",
+		SourceID:   &sourceID,
+		FetchJobID: &fetchJobID,
+		IsRead:     true,
+		CreatedAt:  olderCreatedAt,
+		ReadAt:     &readAt,
+	})
+	newerID := testutil.InsertNotification(t, db, domain.Notification{
+		EventID:    "evt-newer",
+		EventType:  "article.ingested",
+		Level:      "info",
+		Title:      "Newer notification",
+		Body:       "newer body",
+		SourceID:   &sourceID,
+		FetchJobID: &fetchJobID,
+		IsRead:     false,
+		CreatedAt:  newerCreatedAt,
+	})
+
+	// unread filter は新しい通知だけを返し、total と total_pages も filter 後件数で計算される必要がある。
+	isRead := false
+	listed, err := repo.List(context.Background(), domain.ListNotificationsParams{
+		IsRead:   &isRead,
+		Page:     1,
+		PageSize: 1,
+	})
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if listed.Total != 1 || listed.TotalPages != 1 || len(listed.Items) != 1 {
+		t.Fatalf("unexpected list result: %+v", listed)
+	}
+	if listed.Items[0].ID != newerID || listed.Items[0].ReadAt != nil {
+		t.Fatalf("unexpected unread item: %+v", listed.Items[0])
+	}
+
+	// 全件一覧は created_at DESC, id DESC 順に返る前提で画面の先頭表示を守る。
+	all, err := repo.List(context.Background(), domain.ListNotificationsParams{
+		Page:     1,
+		PageSize: 10,
+	})
+	if err != nil {
+		t.Fatalf("List all returned error: %v", err)
+	}
+	if len(all.Items) != 2 || all.Items[0].ID != newerID || all.Items[1].ID != olderID {
+		t.Fatalf("unexpected all notifications order: %+v", all.Items)
+	}
+
+	got, err := repo.GetByID(context.Background(), olderID)
+	if err != nil {
+		t.Fatalf("GetByID returned error: %v", err)
+	}
+	if got == nil || got.SourceID == nil || *got.SourceID != sourceID || got.FetchJobID == nil || *got.FetchJobID != fetchJobID || got.ReadAt == nil {
+		t.Fatalf("unexpected notification payload: %+v", got)
+	}
+
+	updatedRead, err := repo.UpdateReadStatus(context.Background(), newerID, true)
+	if err != nil {
+		t.Fatalf("UpdateReadStatus(true) returned error: %v", err)
+	}
+	if updatedRead == nil || !updatedRead.IsRead || updatedRead.ReadAt == nil {
+		t.Fatalf("expected read notification with read_at, got %+v", updatedRead)
+	}
+
+	updatedUnread, err := repo.UpdateReadStatus(context.Background(), newerID, false)
+	if err != nil {
+		t.Fatalf("UpdateReadStatus(false) returned error: %v", err)
+	}
+	if updatedUnread == nil || updatedUnread.IsRead || updatedUnread.ReadAt != nil {
+		t.Fatalf("expected unread notification without read_at, got %+v", updatedUnread)
+	}
+
+	missing, err := repo.UpdateReadStatus(context.Background(), 999999, true)
+	if err != nil {
+		t.Fatalf("unexpected missing update error: %v", err)
+	}
+	if missing != nil {
+		t.Fatalf("expected nil for missing notification, got %+v", missing)
+	}
+}

--- a/services/notification-service/internal/testutil/mysql.go
+++ b/services/notification-service/internal/testutil/mysql.go
@@ -1,0 +1,193 @@
+package testutil
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	"tech-feed-hub/notification-service/internal/domain"
+)
+
+var schemaInit sync.Once
+
+func OpenMySQLForTest(t *testing.T) *sql.DB {
+	t.Helper()
+
+	if os.Getenv("NOTIFICATION_SERVICE_RUN_INTEGRATION") != "1" {
+		t.Skip("skip mysql integration test; set NOTIFICATION_SERVICE_RUN_INTEGRATION=1 to enable")
+	}
+
+	dsn := strings.TrimSpace(os.Getenv("NOTIFICATION_SERVICE_TEST_MYSQL_DSN"))
+	if dsn == "" {
+		dsn = strings.TrimSpace(os.Getenv("MYSQL_DSN"))
+	}
+	if dsn == "" {
+		dsn = "app_user:app_password@tcp(127.0.0.1:3306)/tech_feed_hub?parseTime=true&multiStatements=true"
+	}
+
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open mysql: %v", err)
+	}
+	db.SetConnMaxLifetime(time.Minute)
+	db.SetMaxOpenConns(5)
+	db.SetMaxIdleConns(5)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		t.Skipf("skip mysql integration test; mysql unavailable for dsn %q: %v", dsn, err)
+	}
+
+	schemaInit.Do(func() {
+		if err := applySchema(ctx, db); err != nil {
+			t.Fatalf("apply schema: %v", err)
+		}
+	})
+
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("close mysql: %v", err)
+		}
+	})
+
+	return db
+}
+
+func ResetMySQLTables(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	stmts := []string{
+		"SET FOREIGN_KEY_CHECKS = 0",
+		"TRUNCATE TABLE notifications",
+		"TRUNCATE TABLE fetch_jobs",
+		"TRUNCATE TABLE articles",
+		"TRUNCATE TABLE sources",
+		"SET FOREIGN_KEY_CHECKS = 1",
+	}
+	for _, stmt := range stmts {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			t.Fatalf("reset tables with %q: %v", stmt, err)
+		}
+	}
+}
+
+func InsertSource(t *testing.T, db *sql.DB, name string) int64 {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := db.ExecContext(ctx, `
+		INSERT INTO sources (name, type, fetch_url, fetch_method, interval_minutes, default_category, is_enabled)
+		VALUES (?, 'rss', ?, 'rss', 60, 'ops', TRUE)`,
+		name,
+		"https://example.com/"+strings.ToLower(strings.ReplaceAll(name, " ", "-"))+".xml",
+	)
+	if err != nil {
+		t.Fatalf("insert source: %v", err)
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("source last insert id: %v", err)
+	}
+	return id
+}
+
+func InsertFetchJob(t *testing.T, db *sql.DB, sourceID int64, status string, startedAt time.Time, finishedAt *time.Time) int64 {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := db.ExecContext(ctx, `
+		INSERT INTO fetch_jobs (source_id, started_at, finished_at, status, fetched_count, inserted_count, duplicated_count, error_message)
+		VALUES (?, ?, ?, ?, 3, 2, 1, ?)`,
+		sourceID,
+		startedAt,
+		finishedAt,
+		status,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("insert fetch job: %v", err)
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("fetch job last insert id: %v", err)
+	}
+	return id
+}
+
+func InsertNotification(t *testing.T, db *sql.DB, notification domain.Notification) int64 {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := db.ExecContext(ctx, `
+		INSERT INTO notifications (event_id, event_type, level, title, body, source_id, fetch_job_id, is_read, created_at, read_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		notification.EventID,
+		notification.EventType,
+		notification.Level,
+		notification.Title,
+		notification.Body,
+		notification.SourceID,
+		notification.FetchJobID,
+		notification.IsRead,
+		notification.CreatedAt,
+		notification.ReadAt,
+	)
+	if err != nil {
+		t.Fatalf("insert notification: %v", err)
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("notification last insert id: %v", err)
+	}
+	return id
+}
+
+func applySchema(ctx context.Context, db *sql.DB) error {
+	schemaPath := filepath.Join(repoRootFromCaller(), "deployments/compose/mysql/init/001_schema.sql")
+	content, err := os.ReadFile(schemaPath)
+	if err != nil {
+		return fmt.Errorf("read schema file: %w", err)
+	}
+
+	for _, stmt := range strings.Split(string(content), ";") {
+		stmt = strings.TrimSpace(stmt)
+		if stmt == "" {
+			continue
+		}
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("exec schema statement: %w", err)
+		}
+	}
+	return nil
+}
+
+func repoRootFromCaller() string {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("resolve caller path")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "..", "..", ".."))
+}


### PR DESCRIPTION
## 概要

- notification-service に repository / router の integration test を追加しました
- frontend に notification 一覧 / source 管理 / source 詳細の component test を追加しました
- 非自明な検証には、テスト意図が追える短いコメントを加えました

## 背景 / 目的

- Issue #31 の目的は、notification 一覧 / 既読更新と source 管理 / source 詳細の回帰テストを追加し、Phase 2-3 の主要補助導線を安定化することです
- 通知既読更新、source enable toggle、fetch job 履歴表示は分岐が多く、frontend / backend の両方で壊れやすいため、自動検証で守ります

## 変更内容

- `services/notification-service/internal/testutil/mysql.go` を追加し、notification-service 用の MySQL integration test helper を追加しました
- `services/notification-service/internal/repository/notification_repository_integration_test.go` を追加し、notification list / read-status 更新 / read_at の DB 契約を検証しました
- `services/notification-service/internal/httpapi/router_integration_test.go` を追加し、notifications list / read-status の 200 / 400 / 404 / 500 を検証しました
- `frontend/src/ui/NotificationListPage.test.tsx` を追加し、list / filter / pagination / 既読更新 / empty / API error を検証しました
- `frontend/src/ui/SourceManagementPage.test.tsx` を追加し、form validation / create / edit / enable toggle / API error を検証しました
- `frontend/src/ui/SourceDetailPage.test.tsx` を追加し、invalid id / source detail / job filter / pagination / empty / API error を検証しました

## 影響範囲

- [x] frontend
- [ ] api-gateway
- [ ] collector-service
- [ ] article-service
- [x] notification-service
- [ ] infra
- [ ] docs

## 検証

- [ ] `go test ./...`
- [x] `npm run build`
- [ ] `docker compose config -q`
- [x] その他: `cd frontend && npm run test:run`
- [x] その他: `cd services/notification-service && GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...`

## API / DB / Infra への影響

- [ ] API を変更した
- [ ] DB schema を変更した
- [ ] Compose を変更した
- [ ] Kubernetes / Helm を変更した
- [x] 大きな影響はない

## ドキュメント

- [ ] 必要に応じて `RULES.md` を更新した
- [ ] 関連する `docs/` を更新した
- [x] ドキュメント更新は不要

## リスク / 注意点

- notification-service の integration test は `NOTIFICATION_SERVICE_RUN_INTEGRATION=1` を前提にしており、未設定時は skip します
- source 管理画面の validation test は、ブラウザの native validation に依存せず zod validation を直接確認する形にしています
- source 詳細の failed filter では複数 job が同じ error message を持つケースを想定し、単一要素前提にしていません

## 補足

- Closes #31