### PR TITLE
test: collector のデータ揺れと service 間契約テストを強化

### DIFF
--- a/docs/openapi/article-service-internal.yaml
+++ b/docs/openapi/article-service-internal.yaml
@@ -1,0 +1,248 @@
+openapi: 3.0.3
+info:
+  title: Article Service Internal API
+  version: 0.1.0
+servers:
+  - url: http://article-service:8081
+paths:
+  /internal/fetch-jobs/start:
+    post:
+      summary: Start fetch job
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/StartFetchJobRequest"
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StartFetchJobResponse"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Source not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /internal/fetch-jobs/{id}/finish:
+    post:
+      summary: Finish fetch job
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FinishFetchJobRequest"
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Fetch job not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Fetch job already finished
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /internal/ingest:
+    post:
+      summary: Ingest normalized articles
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/IngestRequest"
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IngestResponse"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Fetch job not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Fetch job conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+components:
+  schemas:
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+      required:
+        - error
+    IngestSource:
+      type: object
+      properties:
+        name:
+          type: string
+        type:
+          type: string
+          enum:
+            - rss
+        fetch_url:
+          type: string
+          format: uri
+        fetch_method:
+          type: string
+          enum:
+            - rss
+        interval_minutes:
+          type: integer
+        default_category:
+          type: string
+      required:
+        - name
+    StartFetchJobRequest:
+      type: object
+      properties:
+        source_id:
+          type: integer
+        source:
+          allOf:
+            - $ref: "#/components/schemas/IngestSource"
+      description: source_id is preferred. When source_id is omitted, source.name and source.default_category are required.
+    StartFetchJobResponse:
+      type: object
+      properties:
+        source_id:
+          type: integer
+        job_id:
+          type: integer
+      required:
+        - source_id
+        - job_id
+    FinishFetchJobRequest:
+      type: object
+      properties:
+        status:
+          type: string
+          enum:
+            - success
+            - failed
+        fetched_count:
+          type: integer
+          minimum: 0
+        inserted_count:
+          type: integer
+          minimum: 0
+        duplicated_count:
+          type: integer
+          minimum: 0
+        error_message:
+          type: string
+          nullable: true
+      required:
+        - status
+        - fetched_count
+        - inserted_count
+        - duplicated_count
+      description: error_message is required when status is failed.
+    IngestArticle:
+      type: object
+      properties:
+        title:
+          type: string
+        url:
+          type: string
+          format: uri
+        published_at:
+          type: string
+          format: date-time
+          nullable: true
+        fetched_at:
+          type: string
+          format: date-time
+        excerpt:
+          type: string
+        category:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        dedupe_key:
+          type: string
+      required:
+        - title
+        - url
+        - fetched_at
+        - dedupe_key
+    IngestRequest:
+      type: object
+      properties:
+        job_id:
+          type: integer
+        source_id:
+          type: integer
+        source:
+          $ref: "#/components/schemas/IngestSource"
+        articles:
+          type: array
+          items:
+            $ref: "#/components/schemas/IngestArticle"
+      required:
+        - job_id
+        - source_id
+        - source
+        - articles
+    IngestResponse:
+      type: object
+      properties:
+        source_id:
+          type: integer
+        job_id:
+          type: integer
+        fetched_count:
+          type: integer
+        inserted_count:
+          type: integer
+        duplicated_count:
+          type: integer
+      required:
+        - source_id
+        - job_id
+        - fetched_count
+        - inserted_count
+        - duplicated_count

--- a/docs/openapi/article.ingested.json
+++ b/docs/openapi/article.ingested.json
@@ -1,0 +1,15 @@
+{
+  "event_id": "evt-article-ingested-1",
+  "event_type": "article.ingested",
+  "occurred_at": "2026-04-18T03:04:05Z",
+  "source": {
+    "service": "article-service"
+  },
+  "payload": {
+    "job_id": 42,
+    "source_id": 7,
+    "source_name": "Example Feed",
+    "inserted_count": 3,
+    "representative_title": "Example Article"
+  }
+}

--- a/docs/openapi/collector.fetch.failed.json
+++ b/docs/openapi/collector.fetch.failed.json
@@ -1,0 +1,14 @@
+{
+  "event_id": "evt-fetch-failed-1",
+  "event_type": "collector.fetch.failed",
+  "occurred_at": "2026-04-18T03:04:05Z",
+  "source": {
+    "service": "collector-service"
+  },
+  "payload": {
+    "job_id": 42,
+    "source_id": 7,
+    "source_name": "Example Feed",
+    "error_message": "fetch rss status=502"
+  }
+}

--- a/services/article-service/internal/events/publisher.go
+++ b/services/article-service/internal/events/publisher.go
@@ -37,6 +37,13 @@ type RabbitMQPublisher struct {
 	exchange   string
 }
 
+type eventEnvelope struct {
+	EventID    string            `json:"event_id"`
+	EventType  string            `json:"event_type"`
+	OccurredAt time.Time         `json:"occurred_at"`
+	Source     map[string]string `json:"source"`
+}
+
 func NewRabbitMQPublisher(amqpURL string, exchange string) (*RabbitMQPublisher, error) {
 	connection, err := amqp.Dial(amqpURL)
 	if err != nil {
@@ -73,19 +80,7 @@ func (p *RabbitMQPublisher) Close() error {
 }
 
 func (p *RabbitMQPublisher) PublishArticleIngested(ctx context.Context, payload ArticleIngestedPayload) error {
-	body, err := json.Marshal(struct {
-		EventID    string                 `json:"event_id"`
-		EventType  string                 `json:"event_type"`
-		OccurredAt time.Time              `json:"occurred_at"`
-		Source     map[string]string      `json:"source"`
-		Payload    ArticleIngestedPayload `json:"payload"`
-	}{
-		EventID:    newEventID(),
-		EventType:  EventTypeArticleIngested,
-		OccurredAt: time.Now().UTC(),
-		Source:     map[string]string{"service": "article-service"},
-		Payload:    payload,
-	})
+	body, err := marshalArticleIngestedEvent(newEventID(), time.Now().UTC(), payload)
 	if err != nil {
 		return fmt.Errorf("marshal article event: %w", err)
 	}
@@ -104,4 +99,19 @@ func newEventID() string {
 		return fmt.Sprintf("evt-%d", time.Now().UTC().UnixNano())
 	}
 	return hex.EncodeToString(value)
+}
+
+func marshalArticleIngestedEvent(eventID string, occurredAt time.Time, payload ArticleIngestedPayload) ([]byte, error) {
+	return json.Marshal(struct {
+		eventEnvelope
+		Payload ArticleIngestedPayload `json:"payload"`
+	}{
+		eventEnvelope: eventEnvelope{
+			EventID:    eventID,
+			EventType:  EventTypeArticleIngested,
+			OccurredAt: occurredAt.UTC(),
+			Source:     map[string]string{"service": "article-service"},
+		},
+		Payload: payload,
+	})
 }

--- a/services/article-service/internal/events/publisher_test.go
+++ b/services/article-service/internal/events/publisher_test.go
@@ -1,0 +1,58 @@
+package events
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestMarshalArticleIngestedEventMatchesContractFixture(t *testing.T) {
+	t.Parallel()
+
+	title := "Example Article"
+	body, err := marshalArticleIngestedEvent(
+		"evt-article-ingested-1",
+		time.Date(2026, 4, 18, 3, 4, 5, 0, time.UTC),
+		ArticleIngestedPayload{
+			JobID:               42,
+			SourceID:            7,
+			SourceName:          "Example Feed",
+			InsertedCount:       3,
+			RepresentativeTitle: &title,
+		},
+	)
+	if err != nil {
+		t.Fatalf("marshalArticleIngestedEvent returned error: %v", err)
+	}
+
+	assertJSONFixtureEqual(t, fixturePath("article.ingested.json"), body)
+}
+
+func fixturePath(name string) string {
+	return filepath.Join("..", "..", "..", "..", "docs", "openapi", name)
+}
+
+func assertJSONFixtureEqual(t *testing.T, path string, actual []byte) {
+	t.Helper()
+
+	expected, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", path, err)
+	}
+
+	var want any
+	if err := json.Unmarshal(expected, &want); err != nil {
+		t.Fatalf("unmarshal expected fixture: %v", err)
+	}
+	var got any
+	if err := json.Unmarshal(actual, &got); err != nil {
+		t.Fatalf("unmarshal actual json: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("json mismatch\nactual=%s\nexpected=%s", actual, expected)
+	}
+}

--- a/services/article-service/internal/events/publisher_test.go
+++ b/services/article-service/internal/events/publisher_test.go
@@ -12,6 +12,7 @@ import (
 func TestMarshalArticleIngestedEventMatchesContractFixture(t *testing.T) {
 	t.Parallel()
 
+	// article.ingested の envelope と payload を fixture で固定し、producer 側の静かな変更を検知する。
 	title := "Example Article"
 	body, err := marshalArticleIngestedEvent(
 		"evt-article-ingested-1",

--- a/services/article-service/internal/httpapi/router_integration_test.go
+++ b/services/article-service/internal/httpapi/router_integration_test.go
@@ -237,6 +237,7 @@ func TestRouterFetchJobEndpointsAndIngestConflict(t *testing.T) {
 }
 
 func TestRouterInternalEndpointsValidateContract(t *testing.T) {
+	// collector が叩く internal API の 400 shape を固定し、service 間契約の破壊を router 境界で検知する。
 	db, router := newIntegrationRouter(t)
 
 	sourceID := testutil.InsertSource(t, db, domain.Source{

--- a/services/article-service/internal/httpapi/router_integration_test.go
+++ b/services/article-service/internal/httpapi/router_integration_test.go
@@ -236,6 +236,58 @@ func TestRouterFetchJobEndpointsAndIngestConflict(t *testing.T) {
 	}
 }
 
+func TestRouterInternalEndpointsValidateContract(t *testing.T) {
+	db, router := newIntegrationRouter(t)
+
+	sourceID := testutil.InsertSource(t, db, domain.Source{
+		Name:            "Contract Source",
+		Type:            "rss",
+		FetchURL:        "https://example.com/contract.xml",
+		FetchMethod:     "rss",
+		IntervalMinutes: 20,
+		DefaultCategory: "contracts",
+		IsEnabled:       true,
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/internal/fetch-jobs/start", strings.NewReader(`{"source":{"name":"Contract Source"}}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest || !strings.Contains(rec.Body.String(), "source.default_category is required") {
+		t.Fatalf("expected 400 for invalid start request, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/internal/fetch-jobs/start", strings.NewReader(`{"source_id":`+int64String(sourceID)+`}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202 for start fetch job, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var startResp struct {
+		JobID int64 `json:"job_id"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &startResp); err != nil {
+		t.Fatalf("unmarshal start fetch job response: %v", err)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/internal/ingest", bytes.NewBufferString(`{"job_id":`+int64String(startResp.JobID)+`,"source_id":`+int64String(sourceID)+`,"source":{"name":"Contract Source","default_category":"contracts"},"articles":[{"url":"https://example.com/new","fetched_at":"2026-04-16T10:00:00Z","dedupe_key":"new-article"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest || !strings.Contains(rec.Body.String(), "articles[0].title is required") {
+		t.Fatalf("expected 400 for invalid ingest request, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/internal/fetch-jobs/"+int64String(startResp.JobID)+"/finish", bytes.NewBufferString(`{"status":"failed","fetched_count":1,"inserted_count":0,"duplicated_count":1}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest || !strings.Contains(rec.Body.String(), "error_message is required") {
+		t.Fatalf("expected 400 for invalid finish request, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
 func newIntegrationRouter(t *testing.T) (*sql.DB, http.Handler) {
 	t.Helper()
 

--- a/services/article-service/internal/service/article_service.go
+++ b/services/article-service/internal/service/article_service.go
@@ -298,11 +298,8 @@ type IngestResult struct {
 }
 
 func (s *ArticleService) Ingest(ctx context.Context, req IngestRequest) (IngestResult, error) {
-	if req.JobID < 1 {
-		return IngestResult{}, newServiceError(ErrValidation, "job_id is required")
-	}
-	if req.SourceID < 1 {
-		return IngestResult{}, newServiceError(ErrValidation, "source_id is required")
+	if err := validateIngestRequest(req); err != nil {
+		return IngestResult{}, err
 	}
 
 	// job の作成と完了は collector の前後処理に寄せ、ingest 自体は記事登録だけに責務を絞る。
@@ -387,6 +384,10 @@ type StartFetchJobResult struct {
 }
 
 func (s *ArticleService) StartFetchJob(ctx context.Context, input StartFetchJobInput) (StartFetchJobResult, error) {
+	if err := validateStartFetchJobInput(input); err != nil {
+		return StartFetchJobResult{}, err
+	}
+
 	var sourceID int64
 	if input.SourceID > 0 {
 		// source 一覧 API で解決済みの ID が来た場合は、それを job 作成にそのまま使う。
@@ -474,6 +475,51 @@ func (s *ArticleService) FinishFetchJob(ctx context.Context, jobID int64, input 
 	}
 	if err := s.sourceRepo.UpdateFetchStatus(ctx, job.SourceID, input.Status, errorMessage); err != nil {
 		return err
+	}
+	return nil
+}
+
+func validateStartFetchJobInput(input StartFetchJobInput) error {
+	if input.SourceID > 0 {
+		return nil
+	}
+	if strings.TrimSpace(input.Source.Name) == "" {
+		return newServiceError(ErrValidation, "source_id or source.name is required")
+	}
+	if strings.TrimSpace(input.Source.DefaultCategory) == "" {
+		return newServiceError(ErrValidation, "source.default_category is required when source_id is omitted")
+	}
+	return nil
+}
+
+func validateIngestRequest(req IngestRequest) error {
+	if req.JobID < 1 {
+		return newServiceError(ErrValidation, "job_id is required")
+	}
+	if req.SourceID < 1 {
+		return newServiceError(ErrValidation, "source_id is required")
+	}
+	if strings.TrimSpace(req.Source.Name) == "" {
+		return newServiceError(ErrValidation, "source.name is required")
+	}
+
+	defaultCategory := strings.TrimSpace(req.Source.DefaultCategory)
+	for i, article := range req.Articles {
+		if strings.TrimSpace(article.Title) == "" {
+			return newServiceError(ErrValidation, fmt.Sprintf("articles[%d].title is required", i))
+		}
+		if strings.TrimSpace(article.URL) == "" {
+			return newServiceError(ErrValidation, fmt.Sprintf("articles[%d].url is required", i))
+		}
+		if article.FetchedAt.IsZero() {
+			return newServiceError(ErrValidation, fmt.Sprintf("articles[%d].fetched_at is required", i))
+		}
+		if strings.TrimSpace(article.DedupeKey) == "" {
+			return newServiceError(ErrValidation, fmt.Sprintf("articles[%d].dedupe_key is required", i))
+		}
+		if strings.TrimSpace(article.Category) == "" && defaultCategory == "" {
+			return newServiceError(ErrValidation, fmt.Sprintf("articles[%d].category is required when source.default_category is empty", i))
+		}
 	}
 	return nil
 }

--- a/services/article-service/internal/service/article_service_test.go
+++ b/services/article-service/internal/service/article_service_test.go
@@ -308,11 +308,118 @@ func TestIngestRejectsFinishedJob(t *testing.T) {
 		JobID:    10,
 		SourceID: 3,
 		Source: IngestSourceInput{
+			Name:            "Kubernetes Blog",
 			DefaultCategory: "k8s",
 		},
 	})
 	if !errors.Is(err, ErrConflict) {
 		t.Fatalf("expected ErrConflict, got: %v", err)
+	}
+}
+
+func TestIngestRejectsInvalidArticles(t *testing.T) {
+	t.Parallel()
+
+	service := &ArticleService{
+		articleRepo: &stubArticleRepo{
+			bulkUpsertFunc: func(context.Context, int64, []domain.Article) (int, int, error) {
+				t.Fatal("BulkUpsert should not be called")
+				return 0, 0, nil
+			},
+		},
+		sourceRepo: &stubSourceRepo{
+			ensureSourceFunc:      func(context.Context, domain.Source) (int64, error) { return 0, nil },
+			updateFetchStatusFunc: func(context.Context, int64, string, *string) error { return nil },
+		},
+		jobRepo: &stubJobRepo{
+			createFunc:  func(context.Context, int64) (int64, error) { return 0, nil },
+			getByIDFunc: func(context.Context, int64) (*domain.FetchJob, error) { return nil, nil },
+			listFunc: func(context.Context, domain.ListFetchJobsParams) (domain.ListFetchJobsResult, error) {
+				return domain.ListFetchJobsResult{}, nil
+			},
+			finishFunc: func(context.Context, int64, string, int, int, int, *string) error { return nil },
+		},
+	}
+
+	tests := []struct {
+		name    string
+		req     IngestRequest
+		wantErr string
+	}{
+		{
+			name: "missing source name",
+			req: IngestRequest{
+				JobID:    10,
+				SourceID: 3,
+				Source:   IngestSourceInput{DefaultCategory: "k8s"},
+			},
+			wantErr: "source.name is required",
+		},
+		{
+			name: "missing article title",
+			req: IngestRequest{
+				JobID:    10,
+				SourceID: 3,
+				Source:   IngestSourceInput{Name: "Kubernetes Blog", DefaultCategory: "k8s"},
+				Articles: []IngestArticleInput{{URL: "https://example.com/1", FetchedAt: time.Now().UTC(), DedupeKey: "dedupe-1"}},
+			},
+			wantErr: "articles[0].title is required",
+		},
+		{
+			name: "missing article url",
+			req: IngestRequest{
+				JobID:    10,
+				SourceID: 3,
+				Source:   IngestSourceInput{Name: "Kubernetes Blog", DefaultCategory: "k8s"},
+				Articles: []IngestArticleInput{{Title: "First", FetchedAt: time.Now().UTC(), DedupeKey: "dedupe-1"}},
+			},
+			wantErr: "articles[0].url is required",
+		},
+		{
+			name: "missing fetched at",
+			req: IngestRequest{
+				JobID:    10,
+				SourceID: 3,
+				Source:   IngestSourceInput{Name: "Kubernetes Blog", DefaultCategory: "k8s"},
+				Articles: []IngestArticleInput{{Title: "First", URL: "https://example.com/1", DedupeKey: "dedupe-1"}},
+			},
+			wantErr: "articles[0].fetched_at is required",
+		},
+		{
+			name: "missing dedupe key",
+			req: IngestRequest{
+				JobID:    10,
+				SourceID: 3,
+				Source:   IngestSourceInput{Name: "Kubernetes Blog", DefaultCategory: "k8s"},
+				Articles: []IngestArticleInput{{Title: "First", URL: "https://example.com/1", FetchedAt: time.Now().UTC()}},
+			},
+			wantErr: "articles[0].dedupe_key is required",
+		},
+		{
+			name: "missing category without source default",
+			req: IngestRequest{
+				JobID:    10,
+				SourceID: 3,
+				Source:   IngestSourceInput{Name: "Kubernetes Blog"},
+				Articles: []IngestArticleInput{{Title: "First", URL: "https://example.com/1", FetchedAt: time.Now().UTC(), DedupeKey: "dedupe-1"}},
+			},
+			wantErr: "articles[0].category is required",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := service.Ingest(context.Background(), tt.req)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+			if !errors.Is(err, ErrValidation) {
+				t.Fatalf("expected validation error, got %v", err)
+			}
+		})
 	}
 }
 
@@ -439,6 +546,91 @@ func TestListFetchJobsRequiresSourceID(t *testing.T) {
 	}
 
 	_, err := service.ListFetchJobs(context.Background(), domain.ListFetchJobsParams{})
+	if !errors.Is(err, ErrValidation) {
+		t.Fatalf("expected ErrValidation, got: %v", err)
+	}
+}
+
+func TestStartFetchJobRequiresSourceNameOrID(t *testing.T) {
+	t.Parallel()
+
+	service := &ArticleService{
+		articleRepo: &stubArticleRepo{},
+		sourceRepo: &stubSourceRepo{
+			ensureSourceFunc:      func(context.Context, domain.Source) (int64, error) { return 0, nil },
+			updateFetchStatusFunc: func(context.Context, int64, string, *string) error { return nil },
+		},
+		jobRepo: &stubJobRepo{
+			createFunc:  func(context.Context, int64) (int64, error) { return 0, nil },
+			getByIDFunc: func(context.Context, int64) (*domain.FetchJob, error) { return nil, nil },
+			listFunc: func(context.Context, domain.ListFetchJobsParams) (domain.ListFetchJobsResult, error) {
+				return domain.ListFetchJobsResult{}, nil
+			},
+			finishFunc: func(context.Context, int64, string, int, int, int, *string) error { return nil },
+		},
+	}
+
+	_, err := service.StartFetchJob(context.Background(), StartFetchJobInput{})
+	if !errors.Is(err, ErrValidation) {
+		t.Fatalf("expected ErrValidation, got: %v", err)
+	}
+}
+
+func TestStartFetchJobRequiresDefaultCategoryWhenSourceIDOmitted(t *testing.T) {
+	t.Parallel()
+
+	service := &ArticleService{
+		articleRepo: &stubArticleRepo{},
+		sourceRepo: &stubSourceRepo{
+			ensureSourceFunc: func(context.Context, domain.Source) (int64, error) {
+				t.Fatal("EnsureSource should not be called")
+				return 0, nil
+			},
+			updateFetchStatusFunc: func(context.Context, int64, string, *string) error { return nil },
+		},
+		jobRepo: &stubJobRepo{
+			createFunc:  func(context.Context, int64) (int64, error) { return 0, nil },
+			getByIDFunc: func(context.Context, int64) (*domain.FetchJob, error) { return nil, nil },
+			listFunc: func(context.Context, domain.ListFetchJobsParams) (domain.ListFetchJobsResult, error) {
+				return domain.ListFetchJobsResult{}, nil
+			},
+			finishFunc: func(context.Context, int64, string, int, int, int, *string) error { return nil },
+		},
+	}
+
+	_, err := service.StartFetchJob(context.Background(), StartFetchJobInput{
+		Source: IngestSourceInput{Name: "Kubernetes Blog"},
+	})
+	if !errors.Is(err, ErrValidation) {
+		t.Fatalf("expected ErrValidation, got: %v", err)
+	}
+}
+
+func TestFinishFetchJobRequiresErrorMessageWhenFailed(t *testing.T) {
+	t.Parallel()
+
+	service := &ArticleService{
+		articleRepo: &stubArticleRepo{},
+		sourceRepo: &stubSourceRepo{
+			ensureSourceFunc:      func(context.Context, domain.Source) (int64, error) { return 0, nil },
+			updateFetchStatusFunc: func(context.Context, int64, string, *string) error { return nil },
+		},
+		jobRepo: &stubJobRepo{
+			createFunc: func(context.Context, int64) (int64, error) { return 0, nil },
+			getByIDFunc: func(_ context.Context, id int64) (*domain.FetchJob, error) {
+				return &domain.FetchJob{ID: id, SourceID: 9, Status: "running"}, nil
+			},
+			listFunc: func(context.Context, domain.ListFetchJobsParams) (domain.ListFetchJobsResult, error) {
+				return domain.ListFetchJobsResult{}, nil
+			},
+			finishFunc: func(context.Context, int64, string, int, int, int, *string) error {
+				t.Fatal("Finish should not be called")
+				return nil
+			},
+		},
+	}
+
+	err := service.FinishFetchJob(context.Background(), 21, FinishFetchJobInput{Status: "failed"})
 	if !errors.Is(err, ErrValidation) {
 		t.Fatalf("expected ErrValidation, got: %v", err)
 	}

--- a/services/article-service/internal/service/article_service_test.go
+++ b/services/article-service/internal/service/article_service_test.go
@@ -320,6 +320,7 @@ func TestIngestRejectsFinishedJob(t *testing.T) {
 func TestIngestRejectsInvalidArticles(t *testing.T) {
 	t.Parallel()
 
+	// collector からの ingest 契約を API だけでなく service 層でも守り、部分欠損 payload を登録前に止める。
 	service := &ArticleService{
 		articleRepo: &stubArticleRepo{
 			bulkUpsertFunc: func(context.Context, int64, []domain.Article) (int, int, error) {
@@ -554,6 +555,7 @@ func TestListFetchJobsRequiresSourceID(t *testing.T) {
 func TestStartFetchJobRequiresSourceNameOrID(t *testing.T) {
 	t.Parallel()
 
+	// 古い caller 互換を残しつつも、source 解決に必要な最小入力が無い request は受け付けない。
 	service := &ArticleService{
 		articleRepo: &stubArticleRepo{},
 		sourceRepo: &stubSourceRepo{
@@ -579,6 +581,7 @@ func TestStartFetchJobRequiresSourceNameOrID(t *testing.T) {
 func TestStartFetchJobRequiresDefaultCategoryWhenSourceIDOmitted(t *testing.T) {
 	t.Parallel()
 
+	// source_id なし経路では article-service 側で source を解決するため、default_category も必須にする。
 	service := &ArticleService{
 		articleRepo: &stubArticleRepo{},
 		sourceRepo: &stubSourceRepo{
@@ -609,6 +612,7 @@ func TestStartFetchJobRequiresDefaultCategoryWhenSourceIDOmitted(t *testing.T) {
 func TestFinishFetchJobRequiresErrorMessageWhenFailed(t *testing.T) {
 	t.Parallel()
 
+	// failed job は source 一覧や通知に理由を出す前提なので、空の error_message では完了させない。
 	service := &ArticleService{
 		articleRepo: &stubArticleRepo{},
 		sourceRepo: &stubSourceRepo{

--- a/services/collector-service/internal/collector/service.go
+++ b/services/collector-service/internal/collector/service.go
@@ -379,27 +379,35 @@ func (s *Service) fetchRSS(ctx context.Context, source SourceConfig) ([]IngestAr
 	now := time.Now().UTC()
 	articles := make([]IngestArticle, 0, len(feed.Channel.Items))
 	for _, item := range feed.Channel.Items {
-		// source 側の default_category を collector で埋めておき、article-service には正規化済み記事だけを渡す。
-		article := IngestArticle{
-			Title:     strings.TrimSpace(item.Title),
-			URL:       strings.TrimSpace(item.Link),
-			FetchedAt: now,
-			Excerpt:   strings.TrimSpace(stripHTML(item.Description)),
-			Category:  source.DefaultCategory,
-			Tags:      []string{source.DefaultCategory},
-			DedupeKey: dedupeKey(item.Link),
-		}
-		if article.Title == "" || article.URL == "" {
+		article, ok := normalizeRSSItem(item, source, now)
+		if !ok {
 			continue
-		}
-
-		if publishedAt, err := parsePubDate(item.PubDate); err == nil {
-			article.PublishedAt = &publishedAt
 		}
 		articles = append(articles, article)
 	}
 
 	return articles, nil
+}
+
+func normalizeRSSItem(item rssItem, source SourceConfig, fetchedAt time.Time) (IngestArticle, bool) {
+	// source 側の default_category を collector で埋めておき、article-service には正規化済み記事だけを渡す。
+	article := IngestArticle{
+		Title:     strings.TrimSpace(item.Title),
+		URL:       strings.TrimSpace(item.Link),
+		FetchedAt: fetchedAt.UTC(),
+		Excerpt:   strings.TrimSpace(stripHTML(item.Description)),
+		Category:  source.DefaultCategory,
+		Tags:      []string{source.DefaultCategory},
+		DedupeKey: dedupeKey(item.Link),
+	}
+	if article.Title == "" || article.URL == "" {
+		return IngestArticle{}, false
+	}
+
+	if publishedAt, err := parsePubDate(item.PubDate); err == nil {
+		article.PublishedAt = &publishedAt
+	}
+	return article, true
 }
 
 func toIngestSource(source SourceConfig) IngestSource {
@@ -414,6 +422,10 @@ func toIngestSource(source SourceConfig) IngestSource {
 }
 
 func parsePubDate(raw string) (time.Time, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}, fmt.Errorf("unsupported pubDate: %s", raw)
+	}
 	for _, layout := range []string{time.RFC1123Z, time.RFC1123, time.RFC3339} {
 		if parsed, err := time.Parse(layout, raw); err == nil {
 			return parsed.UTC(), nil

--- a/services/collector-service/internal/collector/service_http_test.go
+++ b/services/collector-service/internal/collector/service_http_test.go
@@ -139,6 +139,57 @@ func TestRunReturnsErrorWhenSourceSyncFails(t *testing.T) {
 	}
 }
 
+func TestRunReturnsErrorWhenSourceSyncContainsInvalidSource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string
+	}{
+		{
+			name:    "invalid id",
+			body:    `{"items":[{"id":0,"name":"Example","type":"rss","fetch_url":"http://feed-source/rss","fetch_method":"rss","interval_minutes":30,"default_category":"cloud","is_enabled":true}]}`,
+			wantErr: "invalid id",
+		},
+		{
+			name:    "unsupported type",
+			body:    `{"items":[{"id":7,"name":"Example","type":"html","fetch_url":"http://feed-source/rss","fetch_method":"rss","interval_minutes":30,"default_category":"cloud","is_enabled":true}]}`,
+			wantErr: "unsupported type",
+		},
+		{
+			name:    "missing fetch url",
+			body:    `{"items":[{"id":7,"name":"Example","type":"rss","fetch_url":"","fetch_method":"rss","interval_minutes":30,"default_category":"cloud","is_enabled":true}]}`,
+			wantErr: "empty fetch_url",
+		},
+		{
+			name:    "invalid interval",
+			body:    `{"items":[{"id":7,"name":"Example","type":"rss","fetch_url":"http://feed-source/rss","fetch_method":"rss","interval_minutes":0,"default_category":"cloud","is_enabled":true}]}`,
+			wantErr: "invalid interval_minutes",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			service := NewService("http://article-service")
+			service.client = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				if r.URL.Path != "/api/v1/sources" {
+					t.Fatalf("unexpected path: %s", r.URL.Path)
+				}
+				return newJSONResponse(http.StatusOK, tt.body), nil
+			})}
+
+			_, err := service.Run(context.Background())
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
 func TestRunFinishesFetchJobOnRSSFailure(t *testing.T) {
 	t.Parallel()
 

--- a/services/collector-service/internal/collector/service_http_test.go
+++ b/services/collector-service/internal/collector/service_http_test.go
@@ -142,6 +142,7 @@ func TestRunReturnsErrorWhenSourceSyncFails(t *testing.T) {
 func TestRunReturnsErrorWhenSourceSyncContainsInvalidSource(t *testing.T) {
 	t.Parallel()
 
+	// source の真実源は article-service 側なので、collector では不正な同期結果を即座に弾く。
 	tests := []struct {
 		name    string
 		body    string

--- a/services/collector-service/internal/collector/service_test.go
+++ b/services/collector-service/internal/collector/service_test.go
@@ -9,6 +9,7 @@ import (
 func TestParsePubDate(t *testing.T) {
 	t.Parallel()
 
+	// 外部 RSS の日時形式揺れで collector が静かに壊れないよう、受ける形式と落とす形式を固定する。
 	tests := []struct {
 		name    string
 		raw     string
@@ -87,6 +88,7 @@ func TestStripHTMLNormalizesText(t *testing.T) {
 func TestNormalizeRSSItem(t *testing.T) {
 	t.Parallel()
 
+	// collector で trim / HTML 除去 / category 補完 / UTC 化まで済ませる前提をここで固定する。
 	fetchedAt := time.Date(2026, 4, 18, 1, 2, 3, 0, time.FixedZone("JST", 9*60*60))
 	source := SourceConfig{DefaultCategory: "cloud"}
 
@@ -125,6 +127,7 @@ func TestNormalizeRSSItem(t *testing.T) {
 func TestNormalizeRSSItemSkipsMissingRequiredFields(t *testing.T) {
 	t.Parallel()
 
+	// downstream に不完全な記事を流さないため、title か URL が欠けた item は collector で落とす。
 	for _, item := range []rssItem{
 		{Title: "only title"},
 		{Link: "https://example.com/articles/1"},
@@ -138,6 +141,7 @@ func TestNormalizeRSSItemSkipsMissingRequiredFields(t *testing.T) {
 func TestNormalizeRSSItemAllowsMissingPubDate(t *testing.T) {
 	t.Parallel()
 
+	// pubDate 欠損は外部 RSS で起こり得るため、記事自体は捨てず published_at だけ nil にする。
 	article, ok := normalizeRSSItem(rssItem{
 		Title:       "hello",
 		Link:        "https://example.com/articles/1",

--- a/services/collector-service/internal/collector/service_test.go
+++ b/services/collector-service/internal/collector/service_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -8,22 +9,58 @@ import (
 func TestParsePubDate(t *testing.T) {
 	t.Parallel()
 
-	got, err := parsePubDate("Mon, 02 Jan 2006 15:04:05 +0900")
-	if err != nil {
-		t.Fatalf("parsePubDate returned error: %v", err)
+	tests := []struct {
+		name    string
+		raw     string
+		want    time.Time
+		wantErr string
+	}{
+		{
+			name: "rfc1123z with timezone",
+			raw:  "Mon, 02 Jan 2006 15:04:05 +0900",
+			want: time.Date(2006, 1, 2, 6, 4, 5, 0, time.UTC),
+		},
+		{
+			name: "rfc1123 utc",
+			raw:  "Mon, 02 Jan 2006 15:04:05 UTC",
+			want: time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC),
+		},
+		{
+			name: "rfc3339",
+			raw:  "2006-01-02T15:04:05-07:00",
+			want: time.Date(2006, 1, 2, 22, 4, 5, 0, time.UTC),
+		},
+		{
+			name:    "empty",
+			raw:     "   ",
+			wantErr: "unsupported pubDate",
+		},
+		{
+			name:    "unsupported layout",
+			raw:     "2026/04/14 12:00:00",
+			wantErr: "unsupported pubDate",
+		},
 	}
 
-	want := time.Date(2006, 1, 2, 6, 4, 5, 0, time.UTC)
-	if !got.Equal(want) {
-		t.Fatalf("unexpected parsed time: got=%s want=%s", got, want)
-	}
-}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-func TestParsePubDateReturnsErrorForUnsupportedLayout(t *testing.T) {
-	t.Parallel()
-
-	if _, err := parsePubDate("2026/04/14 12:00:00"); err == nil {
-		t.Fatal("expected error for unsupported layout")
+			got, err := parsePubDate(tt.raw)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parsePubDate returned error: %v", err)
+			}
+			if !got.Equal(tt.want) {
+				t.Fatalf("unexpected parsed time: got=%s want=%s", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -44,5 +81,76 @@ func TestStripHTMLNormalizesText(t *testing.T) {
 	want := "Hello World A & B"
 	if got != want {
 		t.Fatalf("unexpected stripped text: got=%q want=%q", got, want)
+	}
+}
+
+func TestNormalizeRSSItem(t *testing.T) {
+	t.Parallel()
+
+	fetchedAt := time.Date(2026, 4, 18, 1, 2, 3, 0, time.FixedZone("JST", 9*60*60))
+	source := SourceConfig{DefaultCategory: "cloud"}
+
+	article, ok := normalizeRSSItem(rssItem{
+		Title:       "  Launch <b>News</b>  ",
+		Link:        " https://example.com/articles/1 ",
+		Description: "<p>Hello&nbsp;World</p><br />A &amp; B",
+		PubDate:     "Mon, 02 Jan 2006 15:04:05 +0900",
+	}, source, fetchedAt)
+	if !ok {
+		t.Fatal("expected item to be normalized")
+	}
+	if article.Title != "Launch <b>News</b>" {
+		t.Fatalf("unexpected title: %q", article.Title)
+	}
+	if article.URL != "https://example.com/articles/1" {
+		t.Fatalf("unexpected url: %q", article.URL)
+	}
+	if article.Excerpt != "Hello World A & B" {
+		t.Fatalf("unexpected excerpt: %q", article.Excerpt)
+	}
+	if article.Category != "cloud" || len(article.Tags) != 1 || article.Tags[0] != "cloud" {
+		t.Fatalf("unexpected category/tags: %+v", article)
+	}
+	if article.DedupeKey != dedupeKey(" https://example.com/articles/1 ") {
+		t.Fatalf("unexpected dedupe key: %q", article.DedupeKey)
+	}
+	if !article.FetchedAt.Equal(fetchedAt.UTC()) {
+		t.Fatalf("unexpected fetched_at: %s", article.FetchedAt)
+	}
+	if article.PublishedAt == nil || !article.PublishedAt.Equal(time.Date(2006, 1, 2, 6, 4, 5, 0, time.UTC)) {
+		t.Fatalf("unexpected published_at: %+v", article.PublishedAt)
+	}
+}
+
+func TestNormalizeRSSItemSkipsMissingRequiredFields(t *testing.T) {
+	t.Parallel()
+
+	for _, item := range []rssItem{
+		{Title: "only title"},
+		{Link: "https://example.com/articles/1"},
+	} {
+		if _, ok := normalizeRSSItem(item, SourceConfig{DefaultCategory: "cloud"}, time.Now().UTC()); ok {
+			t.Fatalf("expected item to be skipped: %+v", item)
+		}
+	}
+}
+
+func TestNormalizeRSSItemAllowsMissingPubDate(t *testing.T) {
+	t.Parallel()
+
+	article, ok := normalizeRSSItem(rssItem{
+		Title:       "hello",
+		Link:        "https://example.com/articles/1",
+		Description: "<p>line</p>",
+		PubDate:     "",
+	}, SourceConfig{DefaultCategory: "ops"}, time.Now().UTC())
+	if !ok {
+		t.Fatal("expected item to be normalized")
+	}
+	if article.PublishedAt != nil {
+		t.Fatalf("expected published_at to be nil, got %+v", article.PublishedAt)
+	}
+	if article.Excerpt != "line" {
+		t.Fatalf("unexpected excerpt: %q", article.Excerpt)
 	}
 }

--- a/services/collector-service/internal/events/publisher.go
+++ b/services/collector-service/internal/events/publisher.go
@@ -36,6 +36,13 @@ type RabbitMQPublisher struct {
 	exchange   string
 }
 
+type eventEnvelope struct {
+	EventID    string            `json:"event_id"`
+	EventType  string            `json:"event_type"`
+	OccurredAt time.Time         `json:"occurred_at"`
+	Source     map[string]string `json:"source"`
+}
+
 func NewRabbitMQPublisher(amqpURL string, exchange string) (*RabbitMQPublisher, error) {
 	connection, err := amqp.Dial(amqpURL)
 	if err != nil {
@@ -72,19 +79,7 @@ func (p *RabbitMQPublisher) Close() error {
 }
 
 func (p *RabbitMQPublisher) PublishFetchFailed(ctx context.Context, payload FetchFailedPayload) error {
-	body, err := json.Marshal(struct {
-		EventID    string             `json:"event_id"`
-		EventType  string             `json:"event_type"`
-		OccurredAt time.Time          `json:"occurred_at"`
-		Source     map[string]string  `json:"source"`
-		Payload    FetchFailedPayload `json:"payload"`
-	}{
-		EventID:    newEventID(),
-		EventType:  EventTypeCollectorFetchFailed,
-		OccurredAt: time.Now().UTC(),
-		Source:     map[string]string{"service": "collector-service"},
-		Payload:    payload,
-	})
+	body, err := marshalFetchFailedEvent(newEventID(), time.Now().UTC(), payload)
 	if err != nil {
 		return fmt.Errorf("marshal collector event: %w", err)
 	}
@@ -103,4 +98,19 @@ func newEventID() string {
 		return fmt.Sprintf("evt-%d", time.Now().UTC().UnixNano())
 	}
 	return hex.EncodeToString(value)
+}
+
+func marshalFetchFailedEvent(eventID string, occurredAt time.Time, payload FetchFailedPayload) ([]byte, error) {
+	return json.Marshal(struct {
+		eventEnvelope
+		Payload FetchFailedPayload `json:"payload"`
+	}{
+		eventEnvelope: eventEnvelope{
+			EventID:    eventID,
+			EventType:  EventTypeCollectorFetchFailed,
+			OccurredAt: occurredAt.UTC(),
+			Source:     map[string]string{"service": "collector-service"},
+		},
+		Payload: payload,
+	})
 }

--- a/services/collector-service/internal/events/publisher_test.go
+++ b/services/collector-service/internal/events/publisher_test.go
@@ -1,0 +1,56 @@
+package events
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestMarshalFetchFailedEventMatchesContractFixture(t *testing.T) {
+	t.Parallel()
+
+	body, err := marshalFetchFailedEvent(
+		"evt-fetch-failed-1",
+		time.Date(2026, 4, 18, 3, 4, 5, 0, time.UTC),
+		FetchFailedPayload{
+			JobID:        42,
+			SourceID:     7,
+			SourceName:   "Example Feed",
+			ErrorMessage: "fetch rss status=502",
+		},
+	)
+	if err != nil {
+		t.Fatalf("marshalFetchFailedEvent returned error: %v", err)
+	}
+
+	assertJSONFixtureEqual(t, fixturePath("collector.fetch.failed.json"), body)
+}
+
+func fixturePath(name string) string {
+	return filepath.Join("..", "..", "..", "..", "docs", "openapi", name)
+}
+
+func assertJSONFixtureEqual(t *testing.T, path string, actual []byte) {
+	t.Helper()
+
+	expected, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", path, err)
+	}
+
+	var want any
+	if err := json.Unmarshal(expected, &want); err != nil {
+		t.Fatalf("unmarshal expected fixture: %v", err)
+	}
+	var got any
+	if err := json.Unmarshal(actual, &got); err != nil {
+		t.Fatalf("unmarshal actual json: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("json mismatch\nactual=%s\nexpected=%s", actual, expected)
+	}
+}

--- a/services/collector-service/internal/events/publisher_test.go
+++ b/services/collector-service/internal/events/publisher_test.go
@@ -12,6 +12,7 @@ import (
 func TestMarshalFetchFailedEventMatchesContractFixture(t *testing.T) {
 	t.Parallel()
 
+	// consumer 側と別実装でも event shape を崩さないよう、canonical fixture と producer 出力を突き合わせる。
 	body, err := marshalFetchFailedEvent(
 		"evt-fetch-failed-1",
 		time.Date(2026, 4, 18, 3, 4, 5, 0, time.UTC),

--- a/services/notification-service/internal/events/consumer_test.go
+++ b/services/notification-service/internal/events/consumer_test.go
@@ -1,0 +1,158 @@
+package events
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+type stubHandler struct {
+	handleArticleIngestedFunc      func(context.Context, Envelope[ArticleIngestedPayload]) error
+	handleCollectorFetchFailedFunc func(context.Context, Envelope[CollectorFetchFailedPayload]) error
+}
+
+func (h *stubHandler) HandleArticleIngested(ctx context.Context, event Envelope[ArticleIngestedPayload]) error {
+	if h.handleArticleIngestedFunc != nil {
+		return h.handleArticleIngestedFunc(ctx, event)
+	}
+	return nil
+}
+
+func (h *stubHandler) HandleCollectorFetchFailed(ctx context.Context, event Envelope[CollectorFetchFailedPayload]) error {
+	if h.handleCollectorFetchFailedFunc != nil {
+		return h.handleCollectorFetchFailedFunc(ctx, event)
+	}
+	return nil
+}
+
+func TestHandleDeliveryDispatchesArticleIngestedFixture(t *testing.T) {
+	t.Parallel()
+
+	var handled bool
+	consumer := &Consumer{
+		handler: &stubHandler{
+			handleArticleIngestedFunc: func(_ context.Context, event Envelope[ArticleIngestedPayload]) error {
+				handled = true
+				if event.EventType != EventTypeArticleIngested || event.Payload.JobID != 42 || event.Payload.InsertedCount != 3 {
+					t.Fatalf("unexpected event: %+v", event)
+				}
+				return nil
+			},
+		},
+	}
+
+	if err := consumer.handleDelivery(context.Background(), amqp.Delivery{
+		RoutingKey: EventTypeArticleIngested,
+		Body:       mustReadFixture(t, "article.ingested.json"),
+	}); err != nil {
+		t.Fatalf("handleDelivery returned error: %v", err)
+	}
+	if !handled {
+		t.Fatal("expected article handler to be called")
+	}
+}
+
+func TestHandleDeliveryDispatchesCollectorFetchFailedFixture(t *testing.T) {
+	t.Parallel()
+
+	var handled bool
+	consumer := &Consumer{
+		handler: &stubHandler{
+			handleCollectorFetchFailedFunc: func(_ context.Context, event Envelope[CollectorFetchFailedPayload]) error {
+				handled = true
+				if event.EventType != EventTypeCollectorFetchError || event.Payload.SourceID != 7 || event.Payload.ErrorMessage != "fetch rss status=502" {
+					t.Fatalf("unexpected event: %+v", event)
+				}
+				return nil
+			},
+		},
+	}
+
+	if err := consumer.handleDelivery(context.Background(), amqp.Delivery{
+		RoutingKey: EventTypeCollectorFetchError,
+		Body:       mustReadFixture(t, "collector.fetch.failed.json"),
+	}); err != nil {
+		t.Fatalf("handleDelivery returned error: %v", err)
+	}
+	if !handled {
+		t.Fatal("expected collector handler to be called")
+	}
+}
+
+func TestHandleDeliveryIgnoresUnknownEventType(t *testing.T) {
+	t.Parallel()
+
+	consumer := &Consumer{handler: &stubHandler{}}
+	body := []byte(`{"event_type":"unknown.event","payload":{"value":1}}`)
+	if err := consumer.handleDelivery(context.Background(), amqp.Delivery{RoutingKey: "unknown.event", Body: body}); err != nil {
+		t.Fatalf("expected unknown event to be ignored, got %v", err)
+	}
+}
+
+func TestHandleDeliveryReturnsDecodeErrorForMalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	consumer := &Consumer{handler: &stubHandler{}}
+	err := consumer.handleDelivery(context.Background(), amqp.Delivery{RoutingKey: EventTypeArticleIngested, Body: []byte(`{"event_type":`)})
+	if err == nil || !strings.Contains(err.Error(), "decode event header") {
+		t.Fatalf("expected header decode error, got %v", err)
+	}
+}
+
+func TestHandleDeliveryReturnsDecodeErrorForInvalidPayloadShape(t *testing.T) {
+	t.Parallel()
+
+	consumer := &Consumer{handler: &stubHandler{}}
+	body := mustReadFixture(t, "article.ingested.json")
+
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+	payload["payload"] = "invalid"
+	invalid, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal invalid payload: %v", err)
+	}
+
+	err = consumer.handleDelivery(context.Background(), amqp.Delivery{RoutingKey: EventTypeArticleIngested, Body: invalid})
+	if err == nil || !strings.Contains(err.Error(), "decode article event") {
+		t.Fatalf("expected payload decode error, got %v", err)
+	}
+}
+
+func TestHandleDeliveryReturnsHandlerError(t *testing.T) {
+	t.Parallel()
+
+	consumer := &Consumer{
+		handler: &stubHandler{
+			handleCollectorFetchFailedFunc: func(context.Context, Envelope[CollectorFetchFailedPayload]) error {
+				return errors.New("repository down")
+			},
+		},
+	}
+
+	err := consumer.handleDelivery(context.Background(), amqp.Delivery{
+		RoutingKey: EventTypeCollectorFetchError,
+		Body:       mustReadFixture(t, "collector.fetch.failed.json"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "repository down") {
+		t.Fatalf("expected handler error, got %v", err)
+	}
+}
+
+func mustReadFixture(t *testing.T, name string) []byte {
+	t.Helper()
+
+	body, err := os.ReadFile(filepath.Join("..", "..", "..", "..", "docs", "openapi", name))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return body
+}

--- a/services/notification-service/internal/events/consumer_test.go
+++ b/services/notification-service/internal/events/consumer_test.go
@@ -34,6 +34,7 @@ func (h *stubHandler) HandleCollectorFetchFailed(ctx context.Context, event Enve
 func TestHandleDeliveryDispatchesArticleIngestedFixture(t *testing.T) {
 	t.Parallel()
 
+	// producer 側 fixture をそのまま読めることを確認し、event 契約の片側変更を consumer テストで拾う。
 	var handled bool
 	consumer := &Consumer{
 		handler: &stubHandler{
@@ -61,6 +62,7 @@ func TestHandleDeliveryDispatchesArticleIngestedFixture(t *testing.T) {
 func TestHandleDeliveryDispatchesCollectorFetchFailedFixture(t *testing.T) {
 	t.Parallel()
 
+	// collector.fetch.failed も同じ fixture 基準で decode し、routing key ごとの dispatch を固定する。
 	var handled bool
 	consumer := &Consumer{
 		handler: &stubHandler{
@@ -88,6 +90,7 @@ func TestHandleDeliveryDispatchesCollectorFetchFailedFixture(t *testing.T) {
 func TestHandleDeliveryIgnoresUnknownEventType(t *testing.T) {
 	t.Parallel()
 
+	// 未対応 event を poison message にしないよう、unknown type は ignore する現在方針を固定する。
 	consumer := &Consumer{handler: &stubHandler{}}
 	body := []byte(`{"event_type":"unknown.event","payload":{"value":1}}`)
 	if err := consumer.handleDelivery(context.Background(), amqp.Delivery{RoutingKey: "unknown.event", Body: body}); err != nil {
@@ -98,6 +101,7 @@ func TestHandleDeliveryIgnoresUnknownEventType(t *testing.T) {
 func TestHandleDeliveryReturnsDecodeErrorForMalformedJSON(t *testing.T) {
 	t.Parallel()
 
+	// 壊れた JSON は retry 可能な失敗として返し、呼び出し側の Nack(requeue) に流せるようにする。
 	consumer := &Consumer{handler: &stubHandler{}}
 	err := consumer.handleDelivery(context.Background(), amqp.Delivery{RoutingKey: EventTypeArticleIngested, Body: []byte(`{"event_type":`)})
 	if err == nil || !strings.Contains(err.Error(), "decode event header") {
@@ -108,6 +112,7 @@ func TestHandleDeliveryReturnsDecodeErrorForMalformedJSON(t *testing.T) {
 func TestHandleDeliveryReturnsDecodeErrorForInvalidPayloadShape(t *testing.T) {
 	t.Parallel()
 
+	// header だけ読めても payload shape が崩れていれば処理しないことを契約テストで押さえる。
 	consumer := &Consumer{handler: &stubHandler{}}
 	body := mustReadFixture(t, "article.ingested.json")
 
@@ -130,6 +135,7 @@ func TestHandleDeliveryReturnsDecodeErrorForInvalidPayloadShape(t *testing.T) {
 func TestHandleDeliveryReturnsHandlerError(t *testing.T) {
 	t.Parallel()
 
+	// decode 後の保存失敗も呼び出し元に返し、Ack して取りこぼさないことを確認する。
 	consumer := &Consumer{
 		handler: &stubHandler{
 			handleCollectorFetchFailedFunc: func(context.Context, Envelope[CollectorFetchFailedPayload]) error {


### PR DESCRIPTION
## 概要

- collector のデータ揺れテストと service 間契約テストを追加
- article-service internal API の validation を補強
- RabbitMQ event の canonical fixture と internal API spec を docs に追加

## 背景 / 目的

- 外部データ由来の揺れや service 間契約変更を unit だけでは検知しきれないため
- collector -> article-service -> notification-service の破壊をテストで早期検知できるようにするため

## 変更内容

- collector-service
  - RSS 正規化を純関数化し、pubDate / HTML 混在 / 欠損項目 / source sync 不正値のテストを追加
  - `collector.fetch.failed` event の fixture 追従テストを追加
- article-service
  - `/internal/fetch-jobs/start` `/internal/fetch-jobs/{id}/finish` `/internal/ingest` の validation を追加
  - internal API の router integration test を追加
  - `article.ingested` event の fixture 追従テストを追加
- notification-service
  - consumer の dispatch / unknown event / malformed JSON / decode error のテストを追加
- docs
  - article-service internal API spec を追加
  - event fixture を追加

## 影響範囲

- [ ] frontend
- [ ] api-gateway
- [x] collector-service
- [x] article-service
- [x] notification-service
- [ ] infra
- [x] docs

## 検証

- [x] `go test ./...`
- [ ] `npm run build`
- [ ] `docker compose config -q`
- [x] その他:
  - `cd services/collector-service && GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...`
  - `cd services/article-service && GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...`
  - `cd services/notification-service && GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...`

## API / DB / Infra への影響

- [x] API を変更した
- [ ] DB schema を変更した
- [ ] Compose を変更した
- [ ] Kubernetes / Helm を変更した
- [ ] 大きな影響はない

## ドキュメント

- [ ] 必要に応じて `RULES.md` を更新した
- [x] 関連する `docs/` を更新した
- [ ] ドキュメント更新は不要

## リスク / 注意点

- collector / article / notification 間の契約を docs fixture で固定したため、今後 event や internal API を変える場合は docs と各 service のテストを同時更新する必要があります
- `start`/`ingest` の internal validation を厳格化したため、古い caller が不完全な payload を送っている場合は 400 になります

## 補足

- issue: #32