### PR TITLE
test: issue #33 最小 E2E と CI レーン分離を追加する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,4 +19,5 @@ ARTICLE_SERVICE_BASE_URL=http://article-service:8081
 NOTIFICATION_SERVICE_BASE_URL=http://notification-service:8083
 ARTICLE_SERVICE_PUBLIC_URL=http://localhost:8081
 API_GATEWAY_BASE_URL=http://api-gateway:8080
-VITE_API_BASE_URL=http://localhost:8080
+VITE_API_BASE_URL=/
+VITE_PROXY_TARGET=http://localhost:8080

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       docs_only: ${{ steps.filter.outputs.docs == 'true' && steps.filter.outputs.code != 'true' }}
+      e2e_relevant: ${{ steps.filter.outputs.e2e == 'true' }}
 
     steps:
       - name: Checkout
@@ -41,6 +42,18 @@ jobs:
               - '.dockerignore'
               - '.gitignore'
               - 'package*.json'
+            e2e:
+              - '.github/workflows/**'
+              - 'frontend/**'
+              - 'services/api-gateway/**'
+              - 'services/article-service/**'
+              - 'services/notification-service/**'
+              - 'deployments/**'
+              - 'docker-compose.yml'
+              - 'Makefile'
+              - '.env.example'
+              - 'docs/test-policy.md'
+              - 'docs/current-status.md'
 
   verify:
     name: verify
@@ -76,3 +89,53 @@ jobs:
       - name: Skip heavy verification for docs-only changes
         if: needs.changes.outputs.docs_only == 'true'
         run: echo "docs-only change detected; skipping make verify"
+
+  e2e-smoke:
+    name: e2e-smoke
+    runs-on: ubuntu-latest
+    needs: changes
+    timeout-minutes: 30
+    if: needs.changes.outputs.docs_only != 'true' && (github.event_name != 'pull_request' || needs.changes.outputs.e2e_relevant == 'true')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create env file
+        run: cp .env.example .env
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
+
+      - name: Start compose stack
+        run: make e2e-up
+
+      - name: Seed deterministic E2E data
+        run: make e2e-seed
+
+      - name: Run E2E smoke tests
+        run: make test-e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report
+          if-no-files-found: ignore
+
+      - name: Stop compose stack
+        if: always()
+        run: make e2e-down

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 COMPOSE := docker compose
 DEV_COMPOSE := docker compose -f docker-compose.yml -f docker-compose.dev.yml
 
-.PHONY: up down reset logs ps dev-up dev-down dev-logs dev-ps dev-config build test test-article-integration verify
+.PHONY: up down reset logs ps dev-up dev-down dev-logs dev-ps dev-config build test test-article-integration verify e2e-up e2e-seed test-e2e e2e-down
 
 up:
 	$(COMPOSE) up --build
@@ -49,3 +49,16 @@ test-article-integration:
 
 verify: test build
 	$(COMPOSE) config -q
+
+e2e-up:
+	$(COMPOSE) up -d --build mysql rabbitmq article-service notification-service api-gateway frontend
+	./scripts/e2e/wait-for-stack.sh
+
+e2e-seed:
+	./scripts/e2e/seed.sh
+
+test-e2e:
+	cd frontend && npm run test:e2e
+
+e2e-down:
+	$(COMPOSE) down -v

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,11 @@ services:
         condition: service_healthy
       rabbitmq:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8081/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
 
   api-gateway:
     build:
@@ -62,8 +67,15 @@ services:
     ports:
       - "${API_GATEWAY_PORT}:8080"
     depends_on:
-      - article-service
-      - notification-service
+      article-service:
+        condition: service_healthy
+      notification-service:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
 
   collector-service:
     build:
@@ -77,8 +89,10 @@ services:
     ports:
       - "${COLLECTOR_SERVICE_PORT}:8082"
     depends_on:
-      - article-service
-      - rabbitmq
+      article-service:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
 
   notification-service:
     build:
@@ -97,6 +111,11 @@ services:
         condition: service_healthy
       rabbitmq:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8083/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
 
   frontend:
     build:
@@ -104,10 +123,17 @@ services:
       dockerfile: deployments/docker/frontend.Dockerfile
     environment:
       VITE_API_BASE_URL: ${VITE_API_BASE_URL}
+      VITE_PROXY_TARGET: http://api-gateway:8080
     ports:
       - "${FRONTEND_PORT}:5173"
     depends_on:
-      - api-gateway
+      api-gateway:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:5173"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
 
 volumes:
   mysql_data:

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -16,6 +16,7 @@
 - collector-service は source 管理 API と同期しながら RSS 収集と ingest を実行する
 - notification-service と frontend の通知一覧 / 既読更新は実装済み
 - Docker Compose、GitHub Actions、公開 OpenAPI 追従まで整備済み
+- 最小 E2E は未導入で、component test までが自動化の中心になっている
 - Phase 4.5 として、テスト戦略の実装と回帰防止基盤の強化を最優先で進める
 
 ## Verified State
@@ -24,6 +25,7 @@
 - frontend の `npm run build` は通過済み
 - `docker compose config -q` は通過済み
 - `make verify` は通過済み
+- E2E は runner と CI レーンをこれから分離導入する段階
 
 ## Highest Priority Next
 
@@ -50,7 +52,7 @@
 
 - 認証は未実装
 - kind / Helm / Argo CD は未着手
-- frontend の自動テスト基盤は未導入
+- frontend の component test は導入済みだが、実ブラウザ E2E は未導入
 - repository / DB 境界と service 間契約の自動検証は未整備
 
 ## Update Rules

--- a/docs/test-policy.md
+++ b/docs/test-policy.md
@@ -58,6 +58,7 @@
 
 - frontend と gateway の主要ユーザーフロー
 - 記事一覧、詳細、検索、CSV
+- 通知一覧、既読更新
 
 優先度:
 
@@ -140,12 +141,19 @@
 - frontend build
 - compose config validation
 
+PR での扱い:
+
+- `verify` は高速レーンとして常時実行し、`make verify` の責務を維持する
+- E2E は `e2e-smoke` として別レーンに分離し、PR では frontend / gateway / article-service / notification-service / compose / workflow 変更時だけ実行する
+- `main` への push と `workflow_dispatch` では、docs-only を除き `e2e-smoke` も実行する
+
 補足:
 
 - 通常のコード変更では上記を `make verify` で実行する
 - docs-only 変更では、required status check を維持するため `verify` ジョブは成功させる
 - ただし docs-only 変更時は重い `make verify` を省略してよい
 - docs-only 判定条件は workflow 側で管理する
+- `make verify` に E2E は含めず、`make e2e-up` / `make e2e-seed` / `make test-e2e` / `make e2e-down` で責務を分ける
 
 将来的に追加候補:
 
@@ -153,6 +161,19 @@
 - API / event contract test
 - frontend component test
 - kind smoke test
+
+## Minimal E2E Scope
+
+Phase 4.5 で持つ E2E は次の 2 本に限定する。
+
+1. 記事一覧表示 → 検索条件変更 → 詳細遷移 → CSV download
+2. 通知一覧表示 → 既読更新
+
+方針:
+
+- 実行方式は compose ベースとする
+- collector や外部 RSS には依存せず、MySQL に deterministic な seed を投入して再現する
+- flaky 要因になりやすい RabbitMQ 到着待ち、外部 HTTP、現在時刻依存は E2E 導線に含めない
 
 ## Phase 4.5 Priority
 

--- a/frontend/e2e/article-flow.spec.ts
+++ b/frontend/e2e/article-flow.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "@playwright/test";
+
+test("article list flow covers search, detail, and csv export", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.getByRole("heading", { name: "技術情報の一覧・検索" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Platform Weekly Digest" })).toBeVisible();
+
+  await page.getByPlaceholder("タイトル・概要で検索").fill("platform");
+  await page.getByPlaceholder("category 例: kubernetes").fill("kubernetes");
+  await page.getByRole("combobox").selectOption({ label: "E2E Tech Blog" });
+  await page.getByLabel("未読のみ").check();
+  await page.getByLabel("お気に入りのみ").check();
+  await page.getByRole("button", { name: "Search" }).click();
+
+  // list と export が同じ filter 条件を使う前提なので、一覧でも 1 件に絞れることを先に確認する。
+  await expect(page.getByRole("link", { name: "Platform Weekly Digest" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "SRE Incident Review" })).toHaveCount(0);
+
+  await page.getByRole("link", { name: "Platform Weekly Digest" }).click();
+  await expect(page).toHaveURL(/\/articles\/1001$/);
+  await expect(page.getByRole("heading", { name: "Platform Weekly Digest" })).toBeVisible();
+
+  await page.goto("/");
+  await page.getByPlaceholder("タイトル・概要で検索").fill("platform");
+  await page.getByPlaceholder("category 例: kubernetes").fill("kubernetes");
+  await page.getByRole("combobox").selectOption({ label: "E2E Tech Blog" });
+  await page.getByLabel("未読のみ").check();
+  await page.getByLabel("お気に入りのみ").check();
+  await page.getByRole("button", { name: "Search" }).click();
+
+  const downloadPromise = page.waitForEvent("download");
+  await page.getByRole("link", { name: "CSV Download" }).click();
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toMatch(/^articles-\d{8}-\d{6}\.csv$/);
+
+  const csvPath = await download.path();
+  expect(csvPath).not.toBeNull();
+  const csv = await download.createReadStream();
+  expect(csv).not.toBeNull();
+
+  const chunks: Buffer[] = [];
+  for await (const chunk of csv!) {
+    chunks.push(Buffer.from(chunk));
+  }
+  const body = Buffer.concat(chunks).toString("utf8");
+  expect(body).toContain("title,url,source_name,category,published_at,fetched_at,is_read,is_favorite,excerpt,tags");
+  expect(body).toContain("Platform Weekly Digest");
+});

--- a/frontend/e2e/notification-flow.spec.ts
+++ b/frontend/e2e/notification-flow.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "@playwright/test";
+
+test("notification list flow covers read update", async ({ page }) => {
+  await page.goto("/notifications");
+
+  await expect(page.getByRole("heading", { name: "通知一覧" })).toBeVisible();
+  const notification = page.locator("article").filter({ hasText: "Collector failed for E2E feed" });
+  await expect(notification).toBeVisible();
+
+  await notification.getByRole("button", { name: "既読にする" }).click();
+  await expect(notification.getByText("既読")).toBeVisible();
+
+  // mutation 後に一覧 query が invalidation される前提なので、read filter 側でも同じ通知が見えることを確認する。
+  await page.getByLabel("Status").selectOption("read");
+  await expect(page.locator("article").filter({ hasText: "Collector failed for E2E feed" })).toBeVisible();
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "zustand": "^5.0.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.56.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -1310,6 +1311,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@remix-run/router": {
@@ -4104,6 +4121,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,8 @@
     "build": "tsc --noEmit -p tsconfig.json && vite build",
     "test": "vitest",
     "test:run": "vitest run",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -29,6 +31,7 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.3",
+    "@playwright/test": "1.59.1",
     "autoprefixer": "^10.4.20",
     "jsdom": "^29.0.2",
     "msw": "^2.13.4",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
+  reporter: process.env.CI ? [["html", { open: "never" }], ["list"]] : [["list"]],
+  use: {
+    baseURL: process.env.E2E_BASE_URL ?? "http://127.0.0.1:5173",
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 export const api = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8080",
+  baseURL: import.meta.env.VITE_API_BASE_URL ?? "/",
   timeout: 10000,
 });
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,6 +6,12 @@ export default defineConfig({
   server: {
     host: "0.0.0.0",
     port: 5173,
+    proxy: {
+      "/api": {
+        target: process.env.VITE_PROXY_TARGET ?? "http://localhost:8080",
+        changeOrigin: true,
+      },
+    },
     watch:
       process.env.VITE_USE_POLLING === "true"
         ? {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -8,5 +8,7 @@ export default defineConfig({
     globals: true,
     setupFiles: "./src/test/setup.ts",
     css: true,
+    include: ["src/**/*.test.{ts,tsx}"],
+    exclude: ["e2e/**"],
   },
 });

--- a/scripts/e2e/seed.sh
+++ b/scripts/e2e/seed.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT_DIR}"
+
+if [[ ! -f .env ]]; then
+  echo ".env が見つかりません。.env.example をコピーしてから実行してください。" >&2
+  exit 1
+fi
+
+set -a
+source .env
+set +a
+
+for _ in $(seq 1 30); do
+  if docker compose exec -T mysql mysqladmin ping -h localhost -uroot "-p${MYSQL_ROOT_PASSWORD}" --silent >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+done
+
+# collector や RabbitMQ 到着待ちに寄せず、E2E は deterministic な DB 状態を毎回流し込む。
+docker compose exec -T mysql mysql -uroot "-p${MYSQL_ROOT_PASSWORD}" "${MYSQL_DATABASE}" < scripts/e2e/seed.sql

--- a/scripts/e2e/seed.sql
+++ b/scripts/e2e/seed.sql
@@ -1,0 +1,181 @@
+DELETE FROM notifications;
+DELETE FROM articles;
+DELETE FROM fetch_jobs;
+DELETE FROM sources;
+
+ALTER TABLE notifications AUTO_INCREMENT = 1;
+ALTER TABLE articles AUTO_INCREMENT = 1;
+ALTER TABLE fetch_jobs AUTO_INCREMENT = 1;
+ALTER TABLE sources AUTO_INCREMENT = 1;
+
+INSERT INTO sources (
+  id,
+  name,
+  type,
+  fetch_url,
+  fetch_method,
+  interval_minutes,
+  default_category,
+  is_enabled,
+  last_fetched_at,
+  last_fetch_status,
+  last_error_message,
+  created_at,
+  updated_at
+) VALUES
+  (
+    101,
+    'E2E Tech Blog',
+    'rss',
+    'https://example.com/e2e-tech-blog.xml',
+    'rss',
+    60,
+    'kubernetes',
+    TRUE,
+    '2026-04-18 09:00:00',
+    'success',
+    NULL,
+    '2026-04-18 08:00:00',
+    '2026-04-18 09:00:00'
+  ),
+  (
+    102,
+    'Ops Journal',
+    'rss',
+    'https://example.com/ops-journal.xml',
+    'rss',
+    120,
+    'operations',
+    TRUE,
+    '2026-04-18 09:00:00',
+    'success',
+    NULL,
+    '2026-04-18 08:00:00',
+    '2026-04-18 09:00:00'
+  );
+
+INSERT INTO articles (
+  id,
+  title,
+  url,
+  source_id,
+  published_at,
+  fetched_at,
+  excerpt,
+  category,
+  tags,
+  is_read,
+  is_favorite,
+  dedupe_key,
+  created_at,
+  updated_at
+) VALUES
+  (
+    1001,
+    'Platform Weekly Digest',
+    'https://example.com/platform-weekly-digest',
+    101,
+    '2026-04-18 09:30:00',
+    '2026-04-18 10:00:00',
+    'Platform updates for kubernetes teams.',
+    'kubernetes',
+    JSON_ARRAY('kubernetes', 'platform'),
+    FALSE,
+    TRUE,
+    'e2e-platform-weekly-digest',
+    '2026-04-18 10:00:00',
+    '2026-04-18 10:00:00'
+  ),
+  (
+    1002,
+    'SRE Incident Review',
+    'https://example.com/sre-incident-review',
+    102,
+    '2026-04-17 18:00:00',
+    '2026-04-18 10:00:00',
+    'Lessons learned from a recent incident review.',
+    'operations',
+    JSON_ARRAY('operations', 'sre'),
+    TRUE,
+    FALSE,
+    'e2e-sre-incident-review',
+    '2026-04-18 10:00:00',
+    '2026-04-18 10:00:00'
+  );
+
+INSERT INTO fetch_jobs (
+  id,
+  source_id,
+  started_at,
+  finished_at,
+  status,
+  fetched_count,
+  inserted_count,
+  duplicated_count,
+  error_message,
+  created_at
+) VALUES
+  (
+    501,
+    101,
+    '2026-04-18 09:00:00',
+    '2026-04-18 09:03:00',
+    'success',
+    2,
+    1,
+    1,
+    NULL,
+    '2026-04-18 09:00:00'
+  ),
+  (
+    502,
+    102,
+    '2026-04-18 09:05:00',
+    '2026-04-18 09:06:00',
+    'failed',
+    0,
+    0,
+    0,
+    'fetch rss status=502',
+    '2026-04-18 09:05:00'
+  );
+
+INSERT INTO notifications (
+  id,
+  event_id,
+  event_type,
+  level,
+  title,
+  body,
+  source_id,
+  fetch_job_id,
+  is_read,
+  created_at,
+  read_at
+) VALUES
+  (
+    701,
+    'evt-e2e-article-ingested',
+    'article.ingested',
+    'info',
+    'Platform Weekly Digest を取り込みました',
+    'Latest article: Platform Weekly Digest',
+    101,
+    501,
+    TRUE,
+    '2026-04-18 10:01:00',
+    '2026-04-18 10:05:00'
+  ),
+  (
+    702,
+    'evt-e2e-collector-failed',
+    'collector.fetch.failed',
+    'error',
+    'Collector failed for E2E feed',
+    'fetch rss status=502',
+    102,
+    502,
+    FALSE,
+    '2026-04-18 10:02:00',
+    NULL
+  );

--- a/scripts/e2e/wait-for-stack.sh
+++ b/scripts/e2e/wait-for-stack.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT_DIR}"
+
+if [[ ! -f .env ]]; then
+  echo ".env が見つかりません。.env.example をコピーしてから実行してください。" >&2
+  exit 1
+fi
+
+set -a
+source .env
+set +a
+
+wait_for_url() {
+  local url="$1"
+  local label="$2"
+
+  for _ in $(seq 1 60); do
+    if curl -fsS "${url}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+
+  echo "${label} の起動待ちがタイムアウトしました: ${url}" >&2
+  exit 1
+}
+
+# compose の depends_on だけでは host からの利用可能時点までは保証しないため、E2E 前に明示的に待機する。
+wait_for_url "http://127.0.0.1:${ARTICLE_SERVICE_PORT}/health" "article-service"
+wait_for_url "http://127.0.0.1:${NOTIFICATION_SERVICE_PORT}/health" "notification-service"
+wait_for_url "http://127.0.0.1:${API_GATEWAY_PORT}/health" "api-gateway"
+wait_for_url "http://127.0.0.1:${FRONTEND_PORT}" "frontend"


### PR DESCRIPTION
## 概要

- Playwright を導入し、最小 E2E smoke test を 2 本追加
- compose ベースの deterministic seed と起動待機スクリプトを追加
- `make verify` を維持したまま、`e2e-smoke` を GitHub Actions の別レーンとして追加

## 背景 / 目的

- issue #33 の完了条件である「最小 E2E シナリオの追加」「CI での実行対象とタイミングの整理」「`make verify` との責務分離」を満たすため
- frontend / gateway / article-service / notification-service をまたぐ主要導線を、collector や外部 RSS に依存しない形で回帰検知できるようにするため

## 変更内容

- frontend に Playwright 設定と E2E シナリオを追加
- `記事一覧 -> 検索 -> 詳細 -> CSV download` の E2E を追加
- `通知一覧 -> 既読更新` の E2E を追加
- `scripts/e2e/seed.sql` と `scripts/e2e/*.sh` を追加し、compose 起動後に deterministic な DB 状態を投入できるようにした
- `Makefile` に `e2e-up`, `e2e-seed`, `test-e2e`, `e2e-down` を追加
- `docker-compose.yml` に healthcheck と `service_healthy` ベースの依存関係を追加
- frontend 開発サーバー経由で `/api` を proxy するように変更し、実ブラウザ E2E でも同一オリジンで API を叩けるようにした
- `vitest` が `e2e/**` を拾わないように設定を追加
- `.github/workflows/ci.yml` に `e2e-smoke` job を追加し、PR では関連変更時のみ、`main` push と `workflow_dispatch` では docs-only 以外で実行するようにした
- `docs/test-policy.md` と `docs/current-status.md` を更新し、fast lane と E2E の責務分離を明文化した

## 影響範囲

- frontend
- api-gateway
- article-service
- notification-service
- infra
- docs

## 検証

- [x] `go test ./...`
- [x] `npm run build`
- [x] `docker compose config -q`
- [x] その他:
  - `cd frontend && npm run test:run`
  - `make verify`
  - `make e2e-up`
  - `make e2e-seed`
  - `docker run --rm --network host -v /home/syuhei0519/work/app/tech-news-hub/frontend:/work -w /work mcr.microsoft.com/playwright:v1.59.1-jammy sh -lc 'npm ci && npx playwright test'`
  - `make e2e-down`

## API / DB / Infra への影響

- [ ] API を変更した
- [ ] DB schema を変更した
- [x] Compose を変更した
- [ ] Kubernetes / Helm を変更した
- [ ] 大きな影響はない

## ドキュメント

- [ ] 必要に応じて `RULES.md` を更新した
- [x] 関連する `docs/` を更新した
- [ ] ドキュメント更新は不要

## リスク / 注意点

- E2E は seed 前提の smoke test に限定しており、collector 実行や RabbitMQ 到着待ちは対象外
- ローカルで Playwright ブラウザ依存が不足する環境では、PR 記載の Docker 実行コマンドを使う前提

## 補足

- closes #33