### PR TITLE
[Phase 4.5] 改善計画とIssue分解を更新する

### DIFF
--- a/docs/backlog-priority.md
+++ b/docs/backlog-priority.md
@@ -9,23 +9,30 @@
 ### Now
 
 1. `#28` Phase 4.5 テスト戦略の実装と回帰防止基盤の強化
-2. `#29` article-service の repository / handler / MySQL 結合テストを追加する
-3. `#30` frontend のテスト基盤を導入し記事一覧 / 詳細導線を守る
-4. `#31` notification / source 管理周辺のテストを強化する
-5. `#32` collector のデータ揺れケースと service 間契約テストを追加する
-6. `#33` 最小 E2E と CI への組み込み方針を整備する
+2. `#40` Milestone A: 品質ゲート再整理を完了する
+3. `#41` Milestone B: 主要境界の自動検証を完了する
+4. `#42` Milestone C: テスト保守性と可視化を仕上げる
+5. `#43` `make verify` に frontend unit/component test を統合する
+6. `#44` CI を `fast` / `integration` / `smoke` の 3 層に再編する
+7. `#45` article-service の integration test を CI 常設ジョブに載せる
+8. `#46` article-service handler の HTTP integration test を拡充する
+9. `#47` collector -> article-service の契約テストを追加する
+10. `#48` notification-service の DB integration test を追加する
+11. `#49` API の error case テストを強化する
+12. `#50` frontend テスト共通基盤とテストデータ戦略を整理する
+13. `#51` Playwright E2E の seed 安定化と可視化を進める
 
 ### Next
 
-7. `#7` kind デプロイ、Helm Chart、Argo CD の整備
-8. 認証導入
-9. collector の収集戦略拡張
+14. `#7` kind デプロイ、Helm Chart、Argo CD の整備
+15. 認証導入
+16. collector の収集戦略拡張
 
 ### Later
 
-10. `#6` Proxmox クラスタ移行、永続化、監視拡張
-11. 監視基盤の詳細設計
-12. バックアップ / リストア運用の整理
+17. `#6` Proxmox クラスタ移行、永続化、監視拡張
+18. 監視基盤の詳細設計
+19. バックアップ / リストア運用の整理
 
 ## Priority Rules
 

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -30,29 +30,34 @@
 ## Highest Priority Next
 
 1. Phase 4.5 のテスト戦略実装と回帰防止基盤の強化
-2. article-service の repository / handler / MySQL 結合テスト追加
-3. frontend の記事一覧 / 詳細導線テスト基盤追加
-4. notification / source 管理周辺のテスト強化
-5. collector のデータ揺れケースと service 間契約テスト追加
-6. 最小 E2E と CI への組み込み
-7. kind / Helm / Argo CD の整備
+2. Milestone A: 品質ゲート再整理
+3. Milestone B: 主要境界の自動検証
+4. Milestone C: テスト保守性と可視化
+5. kind / Helm / Argo CD の整備
 
 ## Open GitHub Issues
 
 - `#28` `[Phase 4.5]` テスト戦略の実装と回帰防止基盤の強化
-- `#29` `[Phase 4.5]` article-service の repository / handler / MySQL 結合テストを追加する
-- `#30` `[Phase 4.5]` frontend のテスト基盤を導入し記事一覧 / 詳細導線を守る
-- `#31` `[Phase 4.5]` notification / source 管理周辺のテストを強化する
-- `#32` `[Phase 4.5]` collector のデータ揺れケースと service 間契約テストを追加する
-- `#33` `[Phase 4.5]` 最小 E2E と CI への組み込み方針を整備する
+- `#40` `[Phase 4.5][Milestone A]` 品質ゲート再整理を完了する
+- `#41` `[Phase 4.5][Milestone B]` 主要境界の自動検証を完了する
+- `#42` `[Phase 4.5][Milestone C]` テスト保守性と可視化を仕上げる
+- `#43` `[Phase 4.5]` `make verify` に frontend unit/component test を統合する
+- `#44` `[Phase 4.5]` CI を `fast` / `integration` / `smoke` の 3 層に再編する
+- `#45` `[Phase 4.5]` article-service の integration test を CI 常設ジョブに載せる
+- `#46` `[Phase 4.5]` article-service handler の HTTP integration test を拡充する
+- `#47` `[Phase 4.5]` collector -> article-service の契約テストを追加する
+- `#48` `[Phase 4.5]` notification-service の DB integration test を追加する
+- `#49` `[Phase 4.5]` API の error case テストを強化する
+- `#50` `[Phase 4.5]` frontend テスト共通基盤とテストデータ戦略を整理する
+- `#51` `[Phase 4.5]` Playwright E2E の seed 安定化と可視化を進める
 - `#7` `[Phase 5] kind デプロイ、Helm Chart、Argo CD の整備`
 - `#6` `[Phase 6] Proxmox クラスタ移行、永続化、監視拡張`
 
 ## Known Gaps
 
 - 認証は未実装
-- kind / Helm / Argo CD は未着手
-- frontend の component test は導入済みだが、実ブラウザ E2E は未導入
+- kind / Helm / Argo CD は未着手で、Phase 4.5 完了後に着手する
+- frontend の component test と最小 E2E smoke は導入済みだが、標準検証導線と安定化は未完了
 - repository / DB 境界と service 間契約の自動検証は未整備
 
 ## Update Rules

--- a/docs/improvement-plan-phase-4.5.md
+++ b/docs/improvement-plan-phase-4.5.md
@@ -1,0 +1,235 @@
+# Phase 4.5 改善計画
+
+## 目的
+
+`improvement-task-list-tech-news-hub.md` をベースに、現在の実装状況を踏まえて Phase 4.5 の改善を実行計画に落とし込む。
+
+この計画の主眼は、新機能追加ではなく、既存価値を壊さないための品質ゲート、テスト責務、回帰防止基盤の強化である。
+
+## 計画の前提
+
+2026-04-19 時点の前提:
+
+- `make verify` は backend test + frontend build + compose config check を実行する
+- frontend の component test 基盤は導入済み
+- article-service の repository / handler integration test はコード上に存在する
+- Playwright E2E の最小 smoke と CI レーンは導入済み
+- ただし frontend unit/component test と article integration test は標準 verify 導線に未統合
+- CI は `verify` と `e2e-smoke` の 2 レーン中心で、責務の分離がまだ粗い
+
+したがって、改善の中心は「新規テストを書くこと」だけではなく、「既存テストを常設の品質ゲートに組み込むこと」とする。
+
+## 到達目標
+
+Phase 4.5 完了時に、次の状態を作る。
+
+1. 日常の検証コマンドが明確で、ローカルと CI の責務が揃っている
+2. article-service / collector-service / notification-service / frontend の主要責務境界が自動検証される
+3. E2E は最小本数に絞りつつ、再現性高く回る
+4. テスト追加時の作法とデータ戦略が文書化され、継続拡張しやすい
+
+## 非目標
+
+この計画では、次は優先しない。
+
+- Phase 5 の kind / Helm / Argo CD の本格整備
+- 認証導入
+- 大規模な UI 改修や機能追加
+- 監視、バックアップ、本番運用の詳細設計
+
+## 実行方針
+
+- 先に品質ゲートへ組み込めるものから着手し、テスト資産を常設化する
+- article-service を最優先にしつつ、利用者から見える HTTP 契約と service 間契約を固定する
+- E2E は薄く保ち、integration / contract / component に責務を寄せる
+- docs は実装と同じ変更で更新し、運用ルールと乖離させない
+
+## 実施フェーズ
+
+### フェーズ 1: 品質ゲート統合
+
+#### 狙い
+
+既にあるテストを日常導線に組み込み、「書いたが回っていない」状態をなくす。
+
+#### 対象タスク
+
+- `make test-frontend` を追加し、`frontend` の `npm run test:run` を実行可能にする
+- `make verify` に frontend unit/component test を組み込む
+- article-service integration test を `make test-article-integration` で常設運用しやすくする
+- CI を `fast` / `integration` / `smoke` の 3 層に整理する
+- README と `docs/test-policy.md` と `docs/runbook.md` のコマンド説明を同期する
+
+#### 成果物
+
+- 更新された `Makefile`
+- 更新された `.github/workflows/ci.yml`
+- 更新された README / test policy / runbook
+
+#### 完了条件
+
+- `make verify` で backend test + frontend test + build + compose config check が通る
+- CI の job 名と責務が見て分かる
+- `integration` job で article-service integration test が常時実行される
+
+### フェーズ 2: 重要境界の契約固定
+
+#### 狙い
+
+主要な仕様破壊が DB 境界、HTTP 境界、service 間境界で検知できる状態を作る。
+
+#### 対象タスク
+
+- article-service handler integration test を一覧 / 詳細 / 更新 / CSV まで拡充する
+- collector-service から article-service への ingest 契約テストを追加する
+- notification-service の DB integration test を追加する
+- API エラー系のテストを追加する
+
+#### 優先順
+
+1. article-service handler integration
+2. collector -> article-service contract
+3. notification-service DB integration
+4. API error cases
+
+#### 成果物
+
+- article-service の HTTP integration test 拡充
+- collector-service の contract test
+- notification-service の repository or DB integration test
+- エラー系テスト追加
+
+#### 完了条件
+
+- 主要 API の正常系 / 異常系が HTTP レベルで固定される
+- collector の payload 変更が CI で検知できる
+- notification-service の永続化境界が自動で守られる
+
+### フェーズ 3: テスト保守性の改善
+
+#### 狙い
+
+テスト件数が増えても重複、fixture の肥大化、画面ごとの個別実装を抑える。
+
+#### 対象タスク
+
+- frontend の `renderWithProviders`、MSW handler、fixture builder を共通化する
+- テストデータ戦略を文書化する
+- E2E seed と fixture を最小構成へ整理する
+- 時刻依存や外部依存をさらに固定する
+
+#### 成果物
+
+- frontend test helper 群
+- テストデータ方針の文書
+- E2E seed / fixture 整理
+
+#### 完了条件
+
+- 新規画面テスト追加時に共通 helper を再利用できる
+- fixture の置き方と命名が統一される
+- E2E の flaky が目立つ状態でなくなる
+
+### フェーズ 4: 可視化と差分検知の強化
+
+#### 狙い
+
+どこが未保護か、どこで仕様差分が出たかを CI で見えるようにする。
+
+#### 対象タスク
+
+- Go / frontend coverage を artifact 化する
+- OpenAPI lint と breaking change check の導入方針を固める
+- 実装と docs の差分検知を自動化する
+
+#### 成果物
+
+- coverage 出力付き CI
+- OpenAPI 差分検知ジョブ
+
+#### 完了条件
+
+- PR 単位で未テスト領域を把握しやすい
+- API 変更時に docs 更新漏れを検知できる
+
+## 実施順序
+
+最短で効果が出る順序は次の通りとする。
+
+1. `make verify` への frontend test 組み込み
+2. CI 3 層化と article integration 常設
+3. article-service handler integration 拡充
+4. collector 契約テスト
+5. notification-service DB integration
+6. frontend test 共通基盤整理
+7. E2E seed 安定化
+8. エラー系テスト拡充
+9. テストデータ方針の文書化
+10. coverage 可視化
+11. OpenAPI 差分検知
+
+## Issue 対応関係
+
+- `#28`: Phase 4.5 全体親 Issue
+- `#40`: Milestone A の親 Issue
+- `#41`: Milestone B の親 Issue
+- `#42`: Milestone C の親 Issue
+- `#43`: フェーズ 1 の frontend test 導線化
+- `#44`: フェーズ 1 の CI 3 層化
+- `#45`: フェーズ 1 の article integration 常設
+- `#46`: フェーズ 2 の article handler integration
+- `#47`: フェーズ 2 の collector contract test
+- `#48`: フェーズ 2 の notification-service DB integration
+- `#49`: フェーズ 2 の API error cases
+- `#50`: フェーズ 3 の frontend test 共通基盤整理
+- `#51`: フェーズ 3 とフェーズ 4 の E2E 安定化 / 可視化
+
+## 推奨マイルストーン
+
+### マイルストーン A
+
+品質ゲートの再整理を終える。
+
+- `make verify` に frontend test を統合
+- CI 3 層化
+- article integration 常設
+
+### マイルストーン B
+
+主要境界の自動検証を終える。
+
+- article handler integration
+- collector contract test
+- notification DB integration
+- 主要 API の error cases
+
+### マイルストーン C
+
+保守性と可視化を仕上げる。
+
+- frontend test helper 整理
+- E2E seed 安定化
+- test data policy 文書化
+- coverage / OpenAPI 差分検知
+
+## リスクと対策
+
+- CI 時間増加
+  - `fast` と `integration` を分離し、E2E は `smoke` に限定する
+- MySQL 依存テストの不安定化
+  - migration、seed、時刻依存、起動待ちを共通化する
+- テスト追加で fixture が肥大化する
+  - factory / seed / static fixture の使い分けを先に文書化する
+- ドキュメントが実装に追従しない
+  - Makefile / workflow / test policy / runbook を同一 PR で更新する
+
+## Phase 4.5 の完了判定
+
+次を満たしたら、Phase 4.5 は完了とみなす。
+
+- `make verify` が frontend test を含む標準検証導線として機能している
+- CI が `fast` / `integration` / `smoke` の責務で整理されている
+- article-service、collector-service、notification-service の主要境界に自動テストがある
+- E2E smoke が再現性高く維持されている
+- テストポリシーとテストデータ方針が文書化されている
+- coverage または OpenAPI 差分検知の少なくとも一方が CI に入っている


### PR DESCRIPTION
## 概要

- Phase 4.5 の改善計画を docs に追加しました
- 計画を GitHub Issue 群とマイルストーン追跡 Issue に分解した内容を docs に反映しました
- Phase 4.5 を Phase 5 より優先する順序へ整理しました

## 背景 / 目的

- `improvement-task-list-tech-news-hub` をもとに改善計画を整理し、そのまま実行管理できる Issue 構成へ落とし込むため
- ローカル docs と GitHub 上の Issue 実体の番号・優先順が一致している状態にするため
- Phase 5 の kind / Helm / Argo CD 整備より前に Phase 4.5 を進める前提を明文化するため

## 変更内容

- `docs/improvement-plan-phase-4.5.md` を追加
- `docs/backlog-priority.md` を更新し、Phase 4.5 の Issue 群を優先順位順に反映
- `docs/current-status.md` を更新し、現在地と Open Issues を実体の Issue 番号へ同期

## 影響範囲

- docs

## 検証

- [ ] `go test ./...`
- [ ] `npm run build`
- [ ] `docker compose config -q`
- [x] その他:
- docs-only 変更のためテストは未実行
- GitHub Issue `#40` から `#51` の作成と親子関係設定を確認

## API / DB / Infra への影響

- [ ] API を変更した
- [ ] DB schema を変更した
- [ ] Compose を変更した
- [ ] Kubernetes / Helm を変更した
- [x] 大きな影響はない

## ドキュメント

- [ ] 必要に応じて `RULES.md` を更新した
- [x] 関連する `docs/` を更新した
- [ ] ドキュメント更新は不要

## リスク / 注意点

- GitHub Milestone オブジェクト自体は作成しておらず、`#40` `#41` `#42` をマイルストーン追跡 Issue として運用します
- docs の優先順位は GitHub 上の Issue 構成に依存するため、今後の再編時は docs と Issue の同時更新が必要です

## 補足

- 関連親 Issue は `#28` です
- 追加した Issue は `#40` から `#51` です