### PR TITLE
[Phase 4.5] 品質ゲートを fast / integration / smoke に整理する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,8 @@ jobs:
               - 'docs/test-policy.md'
               - 'docs/current-status.md'
 
-  verify:
-    name: verify
+  fast:
+    name: fast
     runs-on: ubuntu-latest
     needs: changes
 
@@ -90,8 +90,44 @@ jobs:
         if: needs.changes.outputs.docs_only == 'true'
         run: echo "docs-only change detected; skipping make verify"
 
-  e2e-smoke:
-    name: e2e-smoke
+  integration:
+    name: integration
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
+
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: root_password
+          MYSQL_DATABASE: tech_feed_hub
+          MYSQL_USER: app_user
+          MYSQL_PASSWORD: app_password
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uapp_user -papp_password"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Run article-service integration tests
+        env:
+          ARTICLE_SERVICE_TEST_MYSQL_DSN: app_user:app_password@tcp(127.0.0.1:3306)/tech_feed_hub?parseTime=true&multiStatements=true
+        run: make test-article-integration
+
+  smoke:
+    name: smoke
     runs-on: ubuntu-latest
     needs: changes
     timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
               - 'docs/current-status.md'
 
   fast:
-    name: fast
+    name: verify
     runs-on: ubuntu-latest
     needs: changes
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test-frontend:
 	cd frontend && npm run test:run
 
 test-article-integration:
-	cd services/article-service && ARTICLE_SERVICE_RUN_INTEGRATION=1 GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...
+	cd services/article-service && ARTICLE_SERVICE_RUN_INTEGRATION=1 GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test -p 1 ./...
 
 verify: test test-frontend build
 	$(COMPOSE) config -q

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 COMPOSE := docker compose
 DEV_COMPOSE := docker compose -f docker-compose.yml -f docker-compose.dev.yml
 
-.PHONY: up down reset logs ps dev-up dev-down dev-logs dev-ps dev-config build test test-article-integration verify e2e-up e2e-seed test-e2e e2e-down
+.PHONY: up down reset logs ps dev-up dev-down dev-logs dev-ps dev-config build test test-frontend test-article-integration verify e2e-up e2e-seed test-e2e e2e-down
 
 up:
 	$(COMPOSE) up --build
@@ -44,10 +44,13 @@ test:
 	cd services/collector-service && GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...
 	cd services/notification-service && GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...
 
+test-frontend:
+	cd frontend && npm run test:run
+
 test-article-integration:
 	cd services/article-service && ARTICLE_SERVICE_RUN_INTEGRATION=1 GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...
 
-verify: test build
+verify: test test-frontend build
 	$(COMPOSE) config -q
 
 e2e-up:

--- a/README.md
+++ b/README.md
@@ -87,11 +87,16 @@ Phase 1 の記事閲覧フローに加えて、Phase 2 の主要機能、Phase 3
 - `make dev-ps`: dev compose の状態確認
 - `make build`: frontend build
 - `make test`: backend test
-- `make verify`: test + build + compose config check
+- `make test-frontend`: frontend unit/component test
+- `make test-article-integration`: article-service の MySQL integration test
+- `make verify`: backend test + frontend test + build + compose config check
 
 補足:
 
-- 通常のコード変更では CI も `make verify` 相当を実行します
+- 通常のコード変更では CI を `fast` / `integration` / `smoke` の 3 レーンで実行します
+- `fast` は `make verify` を実行する高速レーンです
+- `integration` は article-service の MySQL integration test を実行します
+- `smoke` は Playwright E2E を relevant changes 時に実行します
 - docs-only 変更では、GitHub Actions は required check を維持しつつ重い検証を省略します
 - collector-service は `ARTICLE_SERVICE_URL` 経由で source 一覧を取得し、`is_enabled=true` の source を収集します
 - ローカルで即時反映が必要な場合は `docker-compose.dev.yml` を重ねる `make dev-up` を使います

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ Phase 1 の記事閲覧フローに加えて、Phase 2 の主要機能、Phase 3
 
 補足:
 
-- 通常のコード変更では CI を `fast` / `integration` / `smoke` の 3 レーンで実行します
-- `fast` は `make verify` を実行する高速レーンです
+- 通常のコード変更では CI を `verify` / `integration` / `smoke` の 3 レーンで実行します
+- `verify` は `make verify` を実行する高速レーンです
 - `integration` は article-service の MySQL integration test を実行します
 - `smoke` は Playwright E2E を relevant changes 時に実行します
 - docs-only 変更では、GitHub Actions は required check を維持しつつ重い検証を省略します

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -96,7 +96,14 @@ ARTICLE_SERVICE_TEST_MYSQL_DSN='app_user:app_password@tcp(127.0.0.1:3306)/tech_f
 ```bash
 cd frontend
 npm install
+npm run test:run
 npm run build
+```
+
+または:
+
+```bash
+make test-frontend
 ```
 
 ### Compose Config
@@ -116,6 +123,22 @@ make dev-config
 ```bash
 make verify
 ```
+
+補足:
+
+- `make verify` は backend test + frontend test + build + compose config check をまとめて実行する
+- MySQL が必要な article-service integration test は `make verify` に含めない
+
+## CI Lanes
+
+- `fast`: `make verify` を実行する高速レーン
+- `integration`: article-service の MySQL integration test を実行するレーン
+- `smoke`: Playwright E2E を relevant changes 時に実行するレーン
+
+補足:
+
+- docs-only 変更では `fast` は required check を維持しつつ重い検証を省略する
+- `integration` と `smoke` は docs-only 変更では実行しない
 
 ## Health Endpoints
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -131,13 +131,13 @@ make verify
 
 ## CI Lanes
 
-- `fast`: `make verify` を実行する高速レーン
+- `verify`: `make verify` を実行する高速レーン
 - `integration`: article-service の MySQL integration test を実行するレーン
 - `smoke`: Playwright E2E を relevant changes 時に実行するレーン
 
 補足:
 
-- docs-only 変更では `fast` は required check を維持しつつ重い検証を省略する
+- docs-only 変更では `verify` は required check を維持しつつ重い検証を省略する
 - `integration` と `smoke` は docs-only 変更では実行しない
 
 ## Health Endpoints

--- a/docs/test-policy.md
+++ b/docs/test-policy.md
@@ -145,19 +145,19 @@
 
 PR での扱い:
 
-- `fast` は高速レーンとして常時実行し、`make verify` の責務を維持する
+- `verify` は高速レーンとして常時実行し、`make verify` の責務を維持する
 - `integration` は article-service の MySQL integration test を常時実行する
 - `smoke` は E2E レーンとして分離し、PR では frontend / gateway / article-service / notification-service / compose / workflow 変更時だけ実行する
 - `main` への push と `workflow_dispatch` では、docs-only を除き `smoke` も実行する
 
 補足:
 
-- 通常のコード変更では `fast` に `make verify`、`integration` に `make test-article-integration` を割り当てる
-- docs-only 変更では、required status check を維持するため `fast` ジョブは成功させる
+- 通常のコード変更では `verify` に `make verify`、`integration` に `make test-article-integration` を割り当てる
+- docs-only 変更では、required status check を維持するため `verify` ジョブは成功させる
 - ただし docs-only 変更時は重い `make verify` を省略してよい
 - docs-only 判定条件は workflow 側で管理する
 - `make verify` に E2E は含めず、`make e2e-up` / `make e2e-seed` / `make test-e2e` / `make e2e-down` で責務を分ける
-- `integration` は MySQL service container 付きの独立 job とし、`fast` に混ぜない
+- `integration` は MySQL service container 付きの独立 job とし、`verify` に混ぜない
 
 将来的に追加候補:
 

--- a/docs/test-policy.md
+++ b/docs/test-policy.md
@@ -137,29 +137,32 @@
 
 最低限 CI で回す対象:
 
-- Go test
+- backend test
+- frontend unit/component test
 - frontend build
 - compose config validation
+- article-service MySQL integration test
 
 PR での扱い:
 
-- `verify` は高速レーンとして常時実行し、`make verify` の責務を維持する
-- E2E は `e2e-smoke` として別レーンに分離し、PR では frontend / gateway / article-service / notification-service / compose / workflow 変更時だけ実行する
-- `main` への push と `workflow_dispatch` では、docs-only を除き `e2e-smoke` も実行する
+- `fast` は高速レーンとして常時実行し、`make verify` の責務を維持する
+- `integration` は article-service の MySQL integration test を常時実行する
+- `smoke` は E2E レーンとして分離し、PR では frontend / gateway / article-service / notification-service / compose / workflow 変更時だけ実行する
+- `main` への push と `workflow_dispatch` では、docs-only を除き `smoke` も実行する
 
 補足:
 
-- 通常のコード変更では上記を `make verify` で実行する
-- docs-only 変更では、required status check を維持するため `verify` ジョブは成功させる
+- 通常のコード変更では `fast` に `make verify`、`integration` に `make test-article-integration` を割り当てる
+- docs-only 変更では、required status check を維持するため `fast` ジョブは成功させる
 - ただし docs-only 変更時は重い `make verify` を省略してよい
 - docs-only 判定条件は workflow 側で管理する
 - `make verify` に E2E は含めず、`make e2e-up` / `make e2e-seed` / `make test-e2e` / `make e2e-down` で責務を分ける
+- `integration` は MySQL service container 付きの独立 job とし、`fast` に混ぜない
 
 将来的に追加候補:
 
-- MySQL integration test の常時実行拡張
 - API / event contract test
-- frontend component test
+- notification-service など他サービスの MySQL integration test
 - kind smoke test
 
 ## Minimal E2E Scope


### PR DESCRIPTION
## 概要

- `make verify` に frontend unit/component test を組み込みました
- CI を `fast` / `integration` / `smoke` の 3 レーン構成に整理しました
- article-service の MySQL integration test を常設の `integration` レーンへ分離しました
- README と runbook と test policy を新しい検証導線に合わせて更新しました

## 背景 / 目的

- `#40` Milestone A の実装として、既存テストを標準検証導線へ載せるため
- `#43` `#44` `#45` をまとめて実装し、ローカルと CI の品質ゲート責務を揃えるため
- `fast` を重くしすぎず、MySQL 依存の integration と E2E smoke を分離するため

## 変更内容

- `Makefile` に `test-frontend` を追加しました
- `make verify` を backend test + frontend test + build + compose config check に変更しました
- GitHub Actions の job を `fast` / `integration` / `smoke` に再編しました
- `integration` job で MySQL service container を起動し、`make test-article-integration` を実行するようにしました
- `README.md` `docs/runbook.md` `docs/test-policy.md` を新しいレーン構成に合わせて更新しました

## 影響範囲

- article-service
- frontend
- infra
- docs

## 検証

- [x] `go test ./...`
- [x] `npm run build`
- [x] `docker compose config -q`
- [x] その他:
- `make verify`
- `docker compose up -d mysql`
- `ARTICLE_SERVICE_TEST_MYSQL_DSN='app_user:app_password@tcp(127.0.0.1:3306)/tech_feed_hub?parseTime=true&multiStatements=true' make test-article-integration`

## API / DB / Infra への影響

- [ ] API を変更した
- [ ] DB schema を変更した
- [ ] Compose を変更した
- [ ] Kubernetes / Helm を変更した
- [x] 大きな影響はない

## ドキュメント

- [ ] 必要に応じて `RULES.md` を更新した
- [x] 関連する `docs/` を更新した
- [ ] ドキュメント更新は不要

## リスク / 注意点

- `integration` レーンの対象は現時点で article-service のみです
- required check 名が `verify` / `e2e-smoke` から変わるため、GitHub 側の branch protection がある場合は追従が必要です

## 補足

- 関連 Issue: `#40`, `#43`, `#44`, `#45`
- コミット: `a4f8bb7`