### PR TITLE
[Phase 4.5][Milestone B] 主要境界の自動検証を強化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,11 @@ jobs:
           ARTICLE_SERVICE_TEST_MYSQL_DSN: app_user:app_password@tcp(127.0.0.1:3306)/tech_feed_hub?parseTime=true&multiStatements=true
         run: make test-article-integration
 
+      - name: Run notification-service integration tests
+        env:
+          NOTIFICATION_SERVICE_TEST_MYSQL_DSN: app_user:app_password@tcp(127.0.0.1:3306)/tech_feed_hub?parseTime=true&multiStatements=true
+        run: make test-notification-integration
+
   smoke:
     name: smoke
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,23 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/pull_request_template.md'
+      - 'CHANGELOG.md'
+      - 'CODEOWNERS'
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/pull_request_template.md'
+      - 'CHANGELOG.md'
+      - 'CODEOWNERS'
   workflow_dispatch:
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 COMPOSE := docker compose
 DEV_COMPOSE := docker compose -f docker-compose.yml -f docker-compose.dev.yml
 
-.PHONY: up down reset logs ps dev-up dev-down dev-logs dev-ps dev-config build test test-frontend test-article-integration verify e2e-up e2e-seed test-e2e e2e-down
+.PHONY: up down reset logs ps dev-up dev-down dev-logs dev-ps dev-config build test test-frontend test-article-integration test-notification-integration verify e2e-up e2e-seed test-e2e e2e-down
 
 up:
 	$(COMPOSE) up --build
@@ -49,6 +49,9 @@ test-frontend:
 
 test-article-integration:
 	cd services/article-service && ARTICLE_SERVICE_RUN_INTEGRATION=1 GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test -p 1 ./...
+
+test-notification-integration:
+	cd services/notification-service && NOTIFICATION_SERVICE_RUN_INTEGRATION=1 GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test -p 1 ./...
 
 verify: test test-frontend build
 	$(COMPOSE) config -q

--- a/docs/api-guidelines.md
+++ b/docs/api-guidelines.md
@@ -124,6 +124,7 @@
 - `422 Unprocessable Entity`: バリデーション不正
 - `500 Internal Server Error`: 想定外障害
 - `502 Bad Gateway`: upstream service failure
+- `504 Gateway Timeout`: upstream timeout
 
 ### Error Body
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -91,6 +91,19 @@ ARTICLE_SERVICE_TEST_MYSQL_DSN='app_user:app_password@tcp(127.0.0.1:3306)/tech_f
 - `ARTICLE_SERVICE_TEST_MYSQL_DSN` を省略した場合は `127.0.0.1:3306` のローカル MySQL を既定で参照する
 - schema は `deployments/compose/mysql/init/001_schema.sql` をそのまま適用する
 
+### notification-service MySQL Integration Test
+
+```bash
+docker compose up -d mysql
+NOTIFICATION_SERVICE_TEST_MYSQL_DSN='app_user:app_password@tcp(127.0.0.1:3306)/tech_feed_hub?parseTime=true&multiStatements=true' make test-notification-integration
+```
+
+補足:
+
+- integration test は `NOTIFICATION_SERVICE_RUN_INTEGRATION=1` が付いたときだけ実行される
+- `NOTIFICATION_SERVICE_TEST_MYSQL_DSN` を省略した場合は `127.0.0.1:3306` のローカル MySQL を既定で参照する
+- schema は `deployments/compose/mysql/init/001_schema.sql` をそのまま適用する
+
 ### Frontend
 
 ```bash
@@ -127,12 +140,12 @@ make verify
 補足:
 
 - `make verify` は backend test + frontend test + build + compose config check をまとめて実行する
-- MySQL が必要な article-service integration test は `make verify` に含めない
+- MySQL が必要な article-service / notification-service integration test は `make verify` に含めない
 
 ## CI Lanes
 
 - `verify`: `make verify` を実行する高速レーン
-- `integration`: article-service の MySQL integration test を実行するレーン
+- `integration`: article-service と notification-service の MySQL integration test を実行するレーン
 - `smoke`: Playwright E2E を relevant changes 時に実行するレーン
 
 補足:

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -152,6 +152,7 @@ make verify
 
 - docs-only 変更では `verify` は required check を維持しつつ重い検証を省略する
 - `integration` と `smoke` は docs-only 変更では実行しない
+- docs-only の PR / push では CI workflow 自体を起動せず、PR 形式チェック系のみを実行する
 
 ## Health Endpoints
 

--- a/docs/test-policy.md
+++ b/docs/test-policy.md
@@ -142,17 +142,18 @@
 - frontend build
 - compose config validation
 - article-service MySQL integration test
+- notification-service MySQL integration test
 
 PR での扱い:
 
 - `verify` は高速レーンとして常時実行し、`make verify` の責務を維持する
-- `integration` は article-service の MySQL integration test を常時実行する
+- `integration` は article-service と notification-service の MySQL integration test を常時実行する
 - `smoke` は E2E レーンとして分離し、PR では frontend / gateway / article-service / notification-service / compose / workflow 変更時だけ実行する
 - `main` への push と `workflow_dispatch` では、docs-only を除き `smoke` も実行する
 
 補足:
 
-- 通常のコード変更では `verify` に `make verify`、`integration` に `make test-article-integration` を割り当てる
+- 通常のコード変更では `verify` に `make verify`、`integration` に `make test-article-integration` と `make test-notification-integration` を割り当てる
 - docs-only 変更では、required status check を維持するため `verify` ジョブは成功させる
 - ただし docs-only 変更時は重い `make verify` を省略してよい
 - docs-only 判定条件は workflow 側で管理する
@@ -162,7 +163,7 @@ PR での扱い:
 将来的に追加候補:
 
 - API / event contract test
-- notification-service など他サービスの MySQL integration test
+- 他サービスの MySQL integration test 追加
 - kind smoke test
 
 ## Minimal E2E Scope

--- a/docs/test-policy.md
+++ b/docs/test-policy.md
@@ -150,6 +150,7 @@ PR での扱い:
 - `integration` は article-service と notification-service の MySQL integration test を常時実行する
 - `smoke` は E2E レーンとして分離し、PR では frontend / gateway / article-service / notification-service / compose / workflow 変更時だけ実行する
 - `main` への push と `workflow_dispatch` では、docs-only を除き `smoke` も実行する
+- docs-only の PR / push では CI workflow を起動せず、PR 形式チェック系のみを実行する
 
 補足:
 

--- a/services/api-gateway/internal/httpapi/routes.go
+++ b/services/api-gateway/internal/httpapi/routes.go
@@ -1,7 +1,10 @@
 package httpapi
 
 import (
+	"context"
+	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"time"
@@ -92,7 +95,7 @@ func proxyRequest(c *gin.Context, client *http.Client, targetURL string) {
 
 	resp, err := client.Do(req)
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
+		c.JSON(proxyErrorStatus(err), gin.H{"error": err.Error()})
 		return
 	}
 	defer resp.Body.Close()
@@ -123,7 +126,7 @@ func proxyCSVDownload(c *gin.Context, client *http.Client, targetURL string, fil
 
 	resp, err := client.Do(req)
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
+		c.JSON(proxyErrorStatus(err), gin.H{"error": err.Error()})
 		return
 	}
 	defer resp.Body.Close()
@@ -143,4 +146,22 @@ func proxyCSVDownload(c *gin.Context, client *http.Client, targetURL string, fil
 	c.Header("Content-Type", "text/csv; charset=utf-8")
 	c.Header("Content-Disposition", `attachment; filename="`+filename+`"`)
 	c.Data(resp.StatusCode, "text/csv; charset=utf-8", body)
+}
+
+func proxyErrorStatus(err error) int {
+	if err == nil {
+		return http.StatusBadGateway
+	}
+
+	var netErr net.Error
+	switch {
+	case err == context.DeadlineExceeded:
+		return http.StatusGatewayTimeout
+	case errors.Is(err, context.DeadlineExceeded):
+		return http.StatusGatewayTimeout
+	case errors.As(err, &netErr) && netErr.Timeout():
+		return http.StatusGatewayTimeout
+	default:
+		return http.StatusBadGateway
+	}
 }

--- a/services/api-gateway/internal/httpapi/routes_test.go
+++ b/services/api-gateway/internal/httpapi/routes_test.go
@@ -1,6 +1,7 @@
 package httpapi
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -78,6 +79,27 @@ func TestProxyRequestReturnsBadGatewayOnTransportError(t *testing.T) {
 
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("unexpected status code: got=%d want=%d", rec.Code, http.StatusBadGateway)
+	}
+}
+
+func TestProxyRequestReturnsGatewayTimeoutOnDeadlineExceeded(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return nil, context.DeadlineExceeded
+		}),
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/articles", nil)
+
+	proxyRequest(c, client, "http://article-service/api/v1/articles")
+
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Fatalf("unexpected status code: got=%d want=%d", rec.Code, http.StatusGatewayTimeout)
 	}
 }
 
@@ -261,5 +283,26 @@ func TestProxyCSVDownloadPassesThroughErrors(t *testing.T) {
 	}
 	if body := rec.Body.String(); body != `{"error":"invalid from"}` {
 		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
+func TestProxyCSVDownloadReturnsGatewayTimeoutOnDeadlineExceeded(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return nil, context.DeadlineExceeded
+		}),
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/exports/articles.csv", nil)
+
+	proxyCSVDownload(c, client, "http://article-service/api/v1/articles/export.csv", "articles.csv")
+
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Fatalf("unexpected status code: got=%d want=%d", rec.Code, http.StatusGatewayTimeout)
 	}
 }

--- a/services/api-gateway/internal/httpapi/routes_test.go
+++ b/services/api-gateway/internal/httpapi/routes_test.go
@@ -86,6 +86,7 @@ func TestProxyRequestReturnsGatewayTimeoutOnDeadlineExceeded(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)
 
+	// upstream timeout は transport error と分けて 504 にし、利用者と運用の切り分けをしやすくする。
 	client := &http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			return nil, context.DeadlineExceeded
@@ -290,6 +291,7 @@ func TestProxyCSVDownloadReturnsGatewayTimeoutOnDeadlineExceeded(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)
 
+	// CSV download も通常 API と同じ timeout 方針を取り、失敗時の status code を揃える。
 	client := &http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			return nil, context.DeadlineExceeded

--- a/services/article-service/internal/httpapi/router_integration_test.go
+++ b/services/article-service/internal/httpapi/router_integration_test.go
@@ -69,7 +69,34 @@ func TestRouterArticleEndpointsAndCSV(t *testing.T) {
 		t.Fatalf("unexpected list response: %+v", listResp)
 	}
 
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/articles?source_id="+int64String(sourceID)+"&category=k8s&is_read=false&sort=published_at&order=asc&page=1&page_size=1", nil)
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for filtered article list, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &listResp); err != nil {
+		t.Fatalf("unmarshal filtered article list: %v", err)
+	}
+	if listResp.Total != 1 || len(listResp.Items) != 1 || listResp.Items[0].ID != articleID {
+		t.Fatalf("unexpected filtered list response: %+v", listResp)
+	}
+
 	// 詳細と状態更新は未存在 article を 404 にそろえる必要がある。
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/articles/"+int64String(articleID), nil)
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for article detail, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var detail domain.Article
+	if err := json.Unmarshal(rec.Body.Bytes(), &detail); err != nil {
+		t.Fatalf("unmarshal article detail: %v", err)
+	}
+	if detail.ID != articleID || detail.SourceID != sourceID || !detail.IsFavorite || detail.IsRead {
+		t.Fatalf("unexpected article detail: %+v", detail)
+	}
+
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/api/v1/articles/999999", nil)
 	router.ServeHTTP(rec, req)
@@ -85,6 +112,37 @@ func TestRouterArticleEndpointsAndCSV(t *testing.T) {
 		t.Fatalf("expected 404 for missing favorite target, got %d body=%s", rec.Code, rec.Body.String())
 	}
 
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPatch, "/api/v1/articles/"+int64String(articleID)+"/read-status", strings.NewReader(`{"is_read":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for read-status update, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var updatedRead domain.Article
+	if err := json.Unmarshal(rec.Body.Bytes(), &updatedRead); err != nil {
+		t.Fatalf("unmarshal updated read-status article: %v", err)
+	}
+	if !updatedRead.IsRead || !updatedRead.IsFavorite {
+		t.Fatalf("unexpected updated read-status response: %+v", updatedRead)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPatch, "/api/v1/articles/bad/read-status", strings.NewReader(`{"is_read":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid article id, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPatch, "/api/v1/articles/"+int64String(articleID)+"/favorite-status", strings.NewReader(`{"is_favorite":`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid favorite-status payload, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
 	// CSV endpoint は成功時ヘッダと本文の両方を確認する。
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/api/v1/articles/export.csv?source_id=1", nil)
@@ -95,7 +153,7 @@ func TestRouterArticleEndpointsAndCSV(t *testing.T) {
 	if got := rec.Header().Get("Content-Type"); got != "text/csv; charset=utf-8" {
 		t.Fatalf("unexpected csv content type: %s", got)
 	}
-	if body := rec.Body.String(); !strings.Contains(body, "title,url,source_name,category,published_at,fetched_at,is_read,is_favorite,excerpt,tags") || !strings.Contains(body, "Router article") {
+	if body := rec.Body.String(); !strings.HasPrefix(body, "\uFEFFtitle,url,source_name,category,published_at,fetched_at,is_read,is_favorite,excerpt,tags\n") || !strings.Contains(body, "Router article") || !strings.Contains(body, "2026-04-16T08:00:00Z") {
 		t.Fatalf("unexpected csv body: %s", body)
 	}
 

--- a/services/article-service/internal/httpapi/router_integration_test.go
+++ b/services/article-service/internal/httpapi/router_integration_test.go
@@ -69,6 +69,7 @@ func TestRouterArticleEndpointsAndCSV(t *testing.T) {
 		t.Fatalf("unexpected list response: %+v", listResp)
 	}
 
+	// 一覧の複合 filter と sort/paging を router 境界で通し、query 契約の破壊を防ぐ。
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/api/v1/articles?source_id="+int64String(sourceID)+"&category=k8s&is_read=false&sort=published_at&order=asc&page=1&page_size=1", nil)
 	router.ServeHTTP(rec, req)
@@ -112,6 +113,7 @@ func TestRouterArticleEndpointsAndCSV(t *testing.T) {
 		t.Fatalf("expected 404 for missing favorite target, got %d body=%s", rec.Code, rec.Body.String())
 	}
 
+	// read-status 更新成功時は更新済み記事を返し、frontend が再取得なしで状態同期できる前提を守る。
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodPatch, "/api/v1/articles/"+int64String(articleID)+"/read-status", strings.NewReader(`{"is_read":true}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -127,6 +129,7 @@ func TestRouterArticleEndpointsAndCSV(t *testing.T) {
 		t.Fatalf("unexpected updated read-status response: %+v", updatedRead)
 	}
 
+	// id と payload の不正は 404/500 ではなく 400 に寄せる。
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodPatch, "/api/v1/articles/bad/read-status", strings.NewReader(`{"is_read":true}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -143,7 +146,7 @@ func TestRouterArticleEndpointsAndCSV(t *testing.T) {
 		t.Fatalf("expected 400 for invalid favorite-status payload, got %d body=%s", rec.Code, rec.Body.String())
 	}
 
-	// CSV endpoint は成功時ヘッダと本文の両方を確認する。
+	// CSV endpoint は BOM, header order, data row を固定し、一覧と別実装でも利用者契約を維持する。
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/api/v1/articles/export.csv?source_id=1", nil)
 	router.ServeHTTP(rec, req)

--- a/services/collector-service/internal/collector/service_http_test.go
+++ b/services/collector-service/internal/collector/service_http_test.go
@@ -108,6 +108,8 @@ func TestRunCreatesAndFinishesFetchJobOnSuccess(t *testing.T) {
 func TestRunSendsNormalizedIngestContract(t *testing.T) {
 	t.Parallel()
 
+	// collector -> article-service の payload shape を固定し、
+	// 日付正規化・null handling・dedupe_key 生成のズレを検知する。
 	var ingestPayload IngestPayload
 
 	service := NewService("http://article-service")
@@ -149,6 +151,7 @@ func TestRunSendsNormalizedIngestContract(t *testing.T) {
 		t.Fatalf("expected 2 normalized articles, got %+v", ingestPayload.Articles)
 	}
 
+	// pubDate がある記事は RFC3339 UTC に正規化して送る。
 	first := ingestPayload.Articles[0]
 	if first.Title != "RFC1123Z" || first.URL != "https://example.com/with-date" || first.Excerpt != "desc" || first.Category != "cloud" {
 		t.Fatalf("unexpected first normalized article: %+v", first)
@@ -163,6 +166,7 @@ func TestRunSendsNormalizedIngestContract(t *testing.T) {
 		t.Fatalf("unexpected dedupe_key: %s", first.DedupeKey)
 	}
 
+	// pubDate が欠けている記事は ingest 契約上 nil を送り、現在時刻埋めを downstream に持ち込まない。
 	second := ingestPayload.Articles[1]
 	if second.Title != "Missing Date" || second.PublishedAt != nil {
 		t.Fatalf("expected nil published_at for missing date, got %+v", second)
@@ -339,6 +343,7 @@ func TestRunIgnoresPublisherFailureOnRSSFailure(t *testing.T) {
 func TestRunReturnsErrorOnMalformedFeedAndFinishesFetchJob(t *testing.T) {
 	t.Parallel()
 
+	// 壊れた feed でも fetch job は failed で閉じ、UI から失敗履歴を追える状態を維持する。
 	var finishPayload finishFetchJobPayload
 
 	service := NewService("http://article-service")

--- a/services/collector-service/internal/collector/service_http_test.go
+++ b/services/collector-service/internal/collector/service_http_test.go
@@ -2,12 +2,15 @@ package collector
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"tech-feed-hub/collector-service/internal/events"
 )
@@ -99,6 +102,73 @@ func TestRunCreatesAndFinishesFetchJobOnSuccess(t *testing.T) {
 	}
 	if len(results) != 1 || results[0].Status != "success" || results[0].JobID != 11 || results[0].SourceID != 7 {
 		t.Fatalf("unexpected results: %+v", results)
+	}
+}
+
+func TestRunSendsNormalizedIngestContract(t *testing.T) {
+	t.Parallel()
+
+	var ingestPayload IngestPayload
+
+	service := NewService("http://article-service")
+	service.client = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		switch r.URL.Path {
+		case "/api/v1/sources":
+			return newJSONResponse(http.StatusOK, `{"items":[{"id":7,"name":"Example","type":"rss","fetch_url":"http://feed-source/rss","fetch_method":"rss","interval_minutes":30,"default_category":"cloud","is_enabled":true}]}`), nil
+		case "/rss":
+			return newXMLResponse(http.StatusOK, `<?xml version="1.0"?><rss><channel>`+
+				`<item><title>RFC1123Z</title><link>https://example.com/with-date</link><description><![CDATA[<p>desc</p>]]></description><pubDate>Mon, 02 Jan 2006 15:04:05 +0900</pubDate></item>`+
+				`<item><title>Missing Date</title><link>https://example.com/no-date</link><description>plain text</description></item>`+
+				`</channel></rss>`), nil
+		case "/internal/fetch-jobs/start":
+			return newJSONResponse(http.StatusAccepted, `{"source_id":7,"job_id":11}`), nil
+		case "/internal/ingest":
+			if err := json.NewDecoder(r.Body).Decode(&ingestPayload); err != nil {
+				t.Fatalf("decode ingest payload: %v", err)
+			}
+			return newJSONResponse(http.StatusAccepted, `{"source_id":7,"job_id":11,"fetched_count":2,"inserted_count":1,"duplicated_count":1}`), nil
+		case "/internal/fetch-jobs/11/finish":
+			return newJSONResponse(http.StatusNoContent, ``), nil
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+			return nil, nil
+		}
+	})}
+
+	if _, err := service.Run(context.Background()); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if ingestPayload.JobID != 11 || ingestPayload.SourceID != 7 {
+		t.Fatalf("unexpected ingest payload ids: %+v", ingestPayload)
+	}
+	if ingestPayload.Source.Name != "Example" || ingestPayload.Source.DefaultCategory != "cloud" || ingestPayload.Source.FetchMethod != "rss" {
+		t.Fatalf("unexpected ingest source contract: %+v", ingestPayload.Source)
+	}
+	if len(ingestPayload.Articles) != 2 {
+		t.Fatalf("expected 2 normalized articles, got %+v", ingestPayload.Articles)
+	}
+
+	first := ingestPayload.Articles[0]
+	if first.Title != "RFC1123Z" || first.URL != "https://example.com/with-date" || first.Excerpt != "desc" || first.Category != "cloud" {
+		t.Fatalf("unexpected first normalized article: %+v", first)
+	}
+	if first.PublishedAt == nil || first.PublishedAt.Format(time.RFC3339) != "2006-01-02T06:04:05Z" {
+		t.Fatalf("expected normalized published_at, got %+v", first.PublishedAt)
+	}
+	if len(first.Tags) != 1 || first.Tags[0] != "cloud" {
+		t.Fatalf("unexpected first tags: %+v", first.Tags)
+	}
+	if first.DedupeKey != sha256Hex("https://example.com/with-date") {
+		t.Fatalf("unexpected dedupe_key: %s", first.DedupeKey)
+	}
+
+	second := ingestPayload.Articles[1]
+	if second.Title != "Missing Date" || second.PublishedAt != nil {
+		t.Fatalf("expected nil published_at for missing date, got %+v", second)
+	}
+	if second.DedupeKey != sha256Hex("https://example.com/no-date") {
+		t.Fatalf("unexpected second dedupe_key: %s", second.DedupeKey)
 	}
 }
 
@@ -264,4 +334,43 @@ func TestRunIgnoresPublisherFailureOnRSSFailure(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "fetch rss status=502") {
 		t.Fatalf("unexpected error: %v", err)
 	}
+}
+
+func TestRunReturnsErrorOnMalformedFeedAndFinishesFetchJob(t *testing.T) {
+	t.Parallel()
+
+	var finishPayload finishFetchJobPayload
+
+	service := NewService("http://article-service")
+	service.client = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		switch r.URL.Path {
+		case "/api/v1/sources":
+			return newJSONResponse(http.StatusOK, `{"items":[{"id":7,"name":"Example","type":"rss","fetch_url":"http://feed-source/rss","fetch_method":"rss","interval_minutes":60,"default_category":"cloud","is_enabled":true}]}`), nil
+		case "/rss":
+			return newXMLResponse(http.StatusOK, `<rss><channel><item><title>broken</channel></rss>`), nil
+		case "/internal/fetch-jobs/start":
+			return newJSONResponse(http.StatusAccepted, `{"source_id":7,"job_id":11}`), nil
+		case "/internal/fetch-jobs/11/finish":
+			if err := json.NewDecoder(r.Body).Decode(&finishPayload); err != nil {
+				t.Fatalf("decode finish payload: %v", err)
+			}
+			return newJSONResponse(http.StatusNoContent, ``), nil
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+			return nil, nil
+		}
+	})}
+
+	_, err := service.Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "decode rss") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if finishPayload.Status != "failed" || finishPayload.ErrorMessage == nil || !strings.Contains(*finishPayload.ErrorMessage, "decode rss") {
+		t.Fatalf("unexpected finish payload after malformed feed: %+v", finishPayload)
+	}
+}
+
+func sha256Hex(value string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(value)))
+	return fmt.Sprintf("%x", sum[:])
 }

--- a/services/notification-service/internal/repository/notification_repository_integration_test.go
+++ b/services/notification-service/internal/repository/notification_repository_integration_test.go
@@ -110,6 +110,7 @@ func TestNotificationRepositoryListAndReadStatus(t *testing.T) {
 		t.Fatalf("expected nil for missing notification, got %+v", missing)
 	}
 
+	// page 境界でも total / total_pages と並び順が崩れず、画面のページ送りと整合することを確認する。
 	secondPage, err := repo.List(context.Background(), domain.ListNotificationsParams{
 		Page:     2,
 		PageSize: 1,

--- a/services/notification-service/internal/repository/notification_repository_integration_test.go
+++ b/services/notification-service/internal/repository/notification_repository_integration_test.go
@@ -109,4 +109,15 @@ func TestNotificationRepositoryListAndReadStatus(t *testing.T) {
 	if missing != nil {
 		t.Fatalf("expected nil for missing notification, got %+v", missing)
 	}
+
+	secondPage, err := repo.List(context.Background(), domain.ListNotificationsParams{
+		Page:     2,
+		PageSize: 1,
+	})
+	if err != nil {
+		t.Fatalf("List second page returned error: %v", err)
+	}
+	if secondPage.Total != 2 || secondPage.TotalPages != 2 || len(secondPage.Items) != 1 || secondPage.Items[0].ID != olderID {
+		t.Fatalf("unexpected second page result: %+v", secondPage)
+	}
 }

--- a/services/notification-service/internal/service/notification_service_integration_test.go
+++ b/services/notification-service/internal/service/notification_service_integration_test.go
@@ -1,0 +1,77 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"tech-feed-hub/notification-service/internal/domain"
+	"tech-feed-hub/notification-service/internal/events"
+	"tech-feed-hub/notification-service/internal/repository"
+	"tech-feed-hub/notification-service/internal/testutil"
+)
+
+func TestNotificationServicePersistsEventDerivedNotifications(t *testing.T) {
+	db := testutil.OpenMySQLForTest(t)
+	testutil.ResetMySQLTables(t, db)
+
+	repo := repository.NewNotificationRepository(db)
+	svc := NewNotificationService(repo)
+
+	sourceID := testutil.InsertSource(t, db, "Event Source")
+	startedAt := time.Date(2026, 4, 18, 8, 0, 0, 0, time.UTC)
+	finishedAt := startedAt.Add(5 * time.Minute)
+	fetchJobID := testutil.InsertFetchJob(t, db, sourceID, "failed", startedAt, &finishedAt)
+
+	occurredAt := time.Date(2026, 4, 18, 11, 0, 0, 0, time.UTC)
+	title := "New article"
+	if err := svc.HandleArticleIngested(context.Background(), events.Envelope[events.ArticleIngestedPayload]{
+		EventID:    "evt-article-1",
+		EventType:  events.EventTypeArticleIngested,
+		OccurredAt: occurredAt,
+		Payload: events.ArticleIngestedPayload{
+			JobID:               fetchJobID,
+			SourceID:            sourceID,
+			SourceName:          "Event Source",
+			InsertedCount:       2,
+			RepresentativeTitle: &title,
+		},
+	}); err != nil {
+		t.Fatalf("HandleArticleIngested returned error: %v", err)
+	}
+
+	if err := svc.HandleCollectorFetchFailed(context.Background(), events.Envelope[events.CollectorFetchFailedPayload]{
+		EventID:    "evt-fetch-failed-1",
+		EventType:  events.EventTypeCollectorFetchError,
+		OccurredAt: occurredAt.Add(time.Minute),
+		Payload: events.CollectorFetchFailedPayload{
+			JobID:        fetchJobID,
+			SourceID:     sourceID,
+			SourceName:   "Event Source",
+			ErrorMessage: "fetch rss status=502",
+		},
+	}); err != nil {
+		t.Fatalf("HandleCollectorFetchFailed returned error: %v", err)
+	}
+
+	listed, err := repo.List(context.Background(), domain.ListNotificationsParams{
+		Page:     1,
+		PageSize: 10,
+	})
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if listed.Total != 2 || len(listed.Items) != 2 {
+		t.Fatalf("unexpected event-derived notifications: %+v", listed)
+	}
+
+	latest := listed.Items[0]
+	if latest.EventID != "evt-fetch-failed-1" || latest.Level != "error" || latest.SourceID == nil || *latest.SourceID != sourceID || latest.FetchJobID == nil || *latest.FetchJobID != fetchJobID {
+		t.Fatalf("unexpected fetch-failed notification: %+v", latest)
+	}
+
+	older := listed.Items[1]
+	if older.EventID != "evt-article-1" || older.Level != "info" || older.Body != "最新記事: New article" {
+		t.Fatalf("unexpected article-ingested notification: %+v", older)
+	}
+}

--- a/services/notification-service/internal/service/notification_service_integration_test.go
+++ b/services/notification-service/internal/service/notification_service_integration_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestNotificationServicePersistsEventDerivedNotifications(t *testing.T) {
+	// consumer/service から永続化までを MySQL 実体で通し、
+	// event 契約の変更で通知一覧に出る内容が壊れないことを確認する。
 	db := testutil.OpenMySQLForTest(t)
 	testutil.ResetMySQLTables(t, db)
 
@@ -65,11 +67,13 @@ func TestNotificationServicePersistsEventDerivedNotifications(t *testing.T) {
 		t.Fatalf("unexpected event-derived notifications: %+v", listed)
 	}
 
+	// 後着の fetch.failed が先頭に来る前提で、一覧の表示順と level/source 紐付けを固定する。
 	latest := listed.Items[0]
 	if latest.EventID != "evt-fetch-failed-1" || latest.Level != "error" || latest.SourceID == nil || *latest.SourceID != sourceID || latest.FetchJobID == nil || *latest.FetchJobID != fetchJobID {
 		t.Fatalf("unexpected fetch-failed notification: %+v", latest)
 	}
 
+	// article.ingested は representative_title を本文に反映する現在仕様を守る。
 	older := listed.Items[1]
 	if older.EventID != "evt-article-1" || older.Level != "info" || older.Body != "最新記事: New article" {
 		t.Fatalf("unexpected article-ingested notification: %+v", older)


### PR DESCRIPTION
## 概要

- Milestone B として article-service / collector-service / notification-service / api-gateway の主要境界テストを拡充
- notification-service の MySQL integration test を CI `integration` レーンに常設化
- 境界テストに合わせて test policy / runbook / API guideline を更新

## 背景 / 目的

- `#41` の Done Conditions である主要 API の正常系・異常系、collector -> article-service 契約、notification-service の DB 境界、CI 常設実行を満たすため
- 既存機能追加ではなく、Phase 5 前に仕様破壊を PR 時点で検知できる状態を作るため

## 変更内容

- article-service の HTTP integration test に一覧 filter/sort/paging、詳細 200、read/favorite 更新の異常系、CSV の BOM / ヘッダ / 日時フォーマット検証を追加
- collector-service の contract test に ingest payload 正規化、published_at / null handling、dedupe_key、malformed feed failure を追加
- notification-service の repository integration に page 境界を追加し、event 由来通知保存を MySQL integration で検証
- api-gateway で upstream timeout を `504 Gateway Timeout` として扱い、失敗系テストを追加
- `make test-notification-integration` と CI `integration` job を追加し、関連 docs を同期

## 影響範囲

- api-gateway
- collector-service
- article-service
- notification-service
- docs

## 検証

- [x] `cd services/api-gateway && GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...`
- [x] `cd services/collector-service && GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...`
- [x] `cd services/notification-service && GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...`
- [x] `cd services/article-service && GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...`
- [ ] `npm run build`
- [ ] `docker compose config -q`
- [x] その他: `ARTICLE_SERVICE_TEST_MYSQL_DSN=... make test-article-integration`
- [x] その他: `NOTIFICATION_SERVICE_TEST_MYSQL_DSN=... make test-notification-integration`

## API / DB / Infra への影響

- [ ] API を変更した
- [ ] DB schema を変更した
- [ ] Compose を変更した
- [ ] Kubernetes / Helm を変更した
- [x] 大きな影響はない

## ドキュメント

- [ ] 必要に応じて `RULES.md` を更新した
- [x] 関連する `docs/` を更新した
- [ ] ドキュメント更新は不要

## リスク / 注意点

- gateway の timeout は従来 `502` 扱いだったものを `504` に分けているため、失敗系監視や期待ステータスがある場合はこの変更を前提に見る必要があります
- `integration` ジョブに notification-service が加わるため、CI 実行時間はわずかに増えます

## 補足

- Closes #41
- 関連: `#46` `#47` `#48` `#49`