### PR TITLE
docs: Phase 4.5 完了状態へ進捗ドキュメントを同期

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ DevOps / インフラ / クラウド / SRE / CI/CD 関連の技術情報を定�
 
 ## Current Status
 
-Phase 1 の記事閲覧フローに加えて、Phase 2 の主要機能、Phase 3 の通知経路、Phase 4 の基盤整備を実装済みです。次段として、Phase 5 より前に Phase 4.5 のテスト強化を進めます。
+Phase 1 の記事閲覧フローに加えて、Phase 2 の主要機能、Phase 3 の通知経路、Phase 4 の基盤整備、Phase 4.5 のテスト強化まで実装済みです。次段は Phase 5 の kind / Helm / Argo CD 整備です。
 
 - article-service / collector-service / api-gateway / frontend
 - MySQL 接続
@@ -32,8 +32,8 @@ Phase 1 の記事閲覧フローに加えて、Phase 2 の主要機能、Phase 3
 
 現在地:
 
-- Phase 4 の Compose / CI / OpenAPI 整備まで実装済み
-- 次優先は Phase 4.5 のテスト戦略実装と回帰防止基盤の強化
+- Phase 4.5 の品質ゲート、integration test、component test、最小 E2E smoke まで整備済み
+- 次優先は Phase 5 の kind / Helm / Argo CD 整備
 - collector-service は article-service の source 管理 API から実行時に収集対象を同期
 - 検証状態の詳細は `docs/current-status.md` を参照
 
@@ -88,15 +88,34 @@ Phase 1 の記事閲覧フローに加えて、Phase 2 の主要機能、Phase 3
 - `make build`: frontend build
 - `make test`: backend test
 - `make test-frontend`: frontend unit/component test
+- `make test-frontend-coverage`: frontend unit/component test + coverage
 - `make test-article-integration`: article-service の MySQL integration test
+- `make test-notification-integration`: notification-service の MySQL integration test
 - `make verify`: backend test + frontend test + build + compose config check
+- `make e2e-up` / `make e2e-seed` / `make test-e2e` / `make e2e-down`: Playwright E2E smoke
+
+## Testing Overview
+
+- 日常の基本確認ルートは `make verify`
+- DB 境界は `integration` レーンで article-service / notification-service の MySQL integration test を常時確認
+- 主要ユーザーフローは `smoke` レーンで Playwright E2E を relevant changes 時に確認
+- frontend coverage は `coverage` レーンで artifact 化する
+
+テストレイヤの役割:
+
+- Unit / Component: 日常変更で壊れやすいロジックと画面導線を高速に確認する
+- Integration: repository / DB / handler 境界を確認する
+- E2E smoke: 記事導線と通知導線の最小フローだけを確認する
+
+詳細な基準は `docs/test-policy.md` を参照してください。
 
 補足:
 
-- 通常のコード変更では CI を `verify` / `integration` / `smoke` の 3 レーンで実行します
+- 通常のコード変更では CI を `verify` / `integration` / `coverage` / `smoke` のレーンで実行します
 - `verify` は `make verify` を実行する高速レーンです
-- `integration` は article-service の MySQL integration test を実行します
+- `integration` は article-service と notification-service の MySQL integration test を実行します
+- `coverage` は frontend coverage artifact を生成します
 - `smoke` は Playwright E2E を relevant changes 時に実行します
-- docs-only 変更では、GitHub Actions は required check を維持しつつ重い検証を省略します
+- docs-only 変更では、GitHub Actions は `verify` を軽量成功で完了させつつ重い検証を省略します
 - collector-service は `ARTICLE_SERVICE_URL` 経由で source 一覧を取得し、`is_enabled=true` の source を収集します
 - ローカルで即時反映が必要な場合は `docker-compose.dev.yml` を重ねる `make dev-up` を使います

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -23,10 +23,11 @@
 ## Verified State
 
 - Go サービスの `go test ./...` は通過済み
+- frontend の `npm run test:run` は通過済み
 - frontend の `npm run build` は通過済み
 - `docker compose config -q` は通過済み
 - `make verify` は通過済み
-- Playwright smoke と CI レーンは導入済みで、seed 安定化と coverage 可視化が次の仕上げ対象
+- Playwright smoke、integration、coverage を含む CI レーンは導入済み
 
 ## Highest Priority Next
 
@@ -45,8 +46,8 @@
 
 - 認証は未実装
 - kind / Helm / Argo CD は未着手で、これが次の主対象
-- frontend の component test と最小 E2E smoke は導入済みだが、共通 helper 整理と可視化は継続整備中
-- coverage artifact は導入済みで、OpenAPI 差分検知は将来の強化候補
+- OpenAPI 差分検知は未導入で、将来の強化候補
+- kind 着手前のドキュメント同期はこの時点の状態で完了している
 
 ## Update Rules
 


### PR DESCRIPTION
## 概要

- Phase 4.5 と Issue `#28` の完了状態に合わせて進捗系ドキュメントを同期する
- closed になった Phase 4.5 系 Issue を open / backlog 表記から外し、次優先を Phase 5 に揃える
- `README.md` / `docs/current-status.md` / 関連進捗 docs の時制を現状に合わせる

## 背景 / 目的

- `#28` が `completed` で close されたため、現在地や優先順位の文書が古いままだと次セッションで現状認識がぶれる
- 評価コメントのとおり、`README.md` と進捗系 docs の時制が実装状態に追いついていなかった

## 変更内容

- `docs/current-status.md` を Phase 4.5 完了、次優先が Phase 5 である前提に更新
- `docs/backlog-priority.md` から closed issue を外し、open issue ベースの優先順に整理
- `docs/improvement-plan-phase-4.5.md` を Phase 4.5 完了済みとして参照用の記録に更新
- `README.md` の Current Status を現状に合わせて更新し、Testing Overview を追加
- `CHANGELOG.md` の進捗ドキュメント同期に関する表現を現状に合わせて調整

## 影響範囲

- [x] docs
- [ ] frontend
- [ ] api-gateway
- [ ] collector-service
- [ ] article-service
- [ ] notification-service
- [ ] infra

## 検証

- [ ] `go test ./...`
- [ ] `npm run build`
- [ ] `docker compose config -q`
- [x] その他: GitHub の open issue 状態と `#28` の closed/completed を確認し、進捗ドキュメントの記述を実装状態に照合

## API / DB / Infra への影響

- [ ] API を変更した
- [ ] DB schema を変更した
- [ ] Compose を変更した
- [ ] Kubernetes / Helm を変更した
- [x] 大きな影響はない

## ドキュメント

- [ ] 必要に応じて `RULES.md` を更新した
- [x] 関連する `docs/` を更新した
- [ ] ドキュメント更新は不要

## リスク / 注意点

- コードや CI 実装自体は変更しておらず、進捗表現と README の同期が中心
- `tech-news-hub/` の未追跡ディレクトリはこの PR の対象外

## 補足

- 別 PR で docs-only CI の `verify` pending 解消と PR ガードレールの明文化を扱っている