### PR TITLE
docs: Mermaid 図ドキュメントを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,15 @@ DevOps / インフラ / クラウド / SRE / CI/CD 関連の技術情報を定�
 - `services/api-gateway`: フロント向けBFF
 - `services/article-service`: 記事管理API
 - `services/collector-service`: 外部ソース収集API / ジョブ
-- `services/notification-service`: 通知サービス雛形
+- `services/notification-service`: 通知生成・一覧 API サービス
 - `deployments/compose`: Docker Compose 向け設定
 - `deployments/k8s`: kind / Helm / Argo CD 向け土台
 - `docs`: API設計・フェーズ計画
+
+## Architecture And Diagrams
+
+- runtime 構成、記事収集、通知生成、CI / テストレーンの図は [図ドキュメント](docs/diagrams/README.md) から参照できます
+- 図は現行 repo 実装を根拠にしており、`tech-news-hub/` 配下や未実装の将来構成は含めていません
 
 ## Current Status
 

--- a/docs/agent-playbooks.md
+++ b/docs/agent-playbooks.md
@@ -16,6 +16,7 @@
 必要になってから開くもの:
 
 - `docs/openapi/api-gateway.summary.md`
+- [図ドキュメント](diagrams/README.md)
 - `RULES.md`
 - 領域別 guideline
 - `docs/runbook.md`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,6 +23,12 @@
 - `notification-service` はイベントを購読し、通知レコードを生成して公開 API で返す
 - RabbitMQ または `notification-service` の障害は記事閲覧 API の可用性より優先しない
 
+## Related Diagrams
+
+- [システム全体構成図](diagrams/system-overview.md)
+- [記事収集フロー図](diagrams/article-collection-flow.md)
+- [通知生成フロー図](diagrams/notification-generation-flow.md)
+
 ## Kubernetes Readiness
 
 - コンテナ設定は環境変数で外出し

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -1,0 +1,23 @@
+# 図ドキュメント
+
+このディレクトリには、ルート repo の現行実装を前提にした Mermaid 図をまとめています。
+README や個別 docs から辿れるようにし、runtime 構成、主要フロー、CI / テストレーンを短時間で把握できるようにするのが目的です。
+
+今回の図はこのルート repo を対象にしており、`tech-news-hub/` 配下は含めていません。
+また、kind / Helm / Argo CD、監視基盤、Redis など repo 上で未実装の将来要素は図に含めていません。
+
+## 一覧
+
+- [システム全体構成図](system-overview.md)
+  - frontend、api-gateway、各 service、MySQL、RabbitMQ、外部 RSS の関係を示します。
+- [記事収集フロー図](article-collection-flow.md)
+  - `collector-service` が source 同期、fetch job 管理、RSS 正規化、ingest をどう進めるかを示します。
+- [通知生成フロー図](notification-generation-flow.md)
+  - `article.ingested` と `collector.fetch.failed` が通知一覧に見えるまでの非同期経路を示します。
+- [CI / テストレーン構成図](ci-test-lanes.md)
+  - `changes -> verify / integration / coverage / smoke` の条件分岐と責務を示します。
+
+## 補足
+
+- 図には repo から断定できるものだけを載せています。
+- 曖昧な点は図本体には描かず、各ファイルの注記に `repo からは未確定` として分けています。

--- a/docs/diagrams/article-collection-flow.md
+++ b/docs/diagrams/article-collection-flow.md
@@ -32,11 +32,11 @@ sequenceDiagram
       Collector->>Article: POST /internal/ingest
       Article->>DB: bulk upsert articles
       Article-->>Collector: inserted_count, duplicated_count
-      Collector->>Article: POST /internal/fetch-jobs/{id}/finish success
+      Collector->>Article: POST /internal/fetch-jobs/:id/finish success
       Article->>DB: update fetch_jobs and source status
       Article-->>Collector: 204 No Content
     else RSS fetch or ingest fails
-      Collector->>Article: POST /internal/fetch-jobs/{id}/finish failed
+      Collector->>Article: POST /internal/fetch-jobs/:id/finish failed
       Article->>DB: update fetch_jobs and source status
       Article-->>Collector: 204 No Content
       Note over Collector: Current implementation returns partial results<br/>and stops on the first error.

--- a/docs/diagrams/article-collection-flow.md
+++ b/docs/diagrams/article-collection-flow.md
@@ -6,44 +6,44 @@
 ```mermaid
 sequenceDiagram
   autonumber
-  actor Caller as External caller<br/>manual / API-triggered collection
+  actor Caller as 外部呼び出し元<br/>手動 / API-triggered collection
   participant Collector as collector-service
   participant Article as article-service
-  participant RSS as External RSS source
+  participant RSS as 外部 RSS source
   participant DB as MySQL
 
   Caller->>Collector: POST /api/v1/collect/run
   Collector->>Article: GET /api/v1/sources
-  Article->>DB: read sources
+  Article->>DB: sources を取得
   DB-->>Article: source rows
   Article-->>Collector: items
-  Note over Collector: Disabled sources are skipped.<br/>Enabled sources are processed sequentially.
+  Note over Collector: disabled の source は除外する。<br/>enabled の source は順次処理する。
 
-  loop each enabled source
+  loop enabled な source ごと
     Collector->>Article: POST /internal/fetch-jobs/start
-    Article->>DB: insert fetch_jobs(status=running)
+    Article->>DB: fetch_jobs に running を記録
     Article-->>Collector: source_id, job_id
 
     Collector->>RSS: GET fetch_url
 
-    alt RSS fetch and ingest succeed
+    alt RSS 取得と ingest が成功
       RSS-->>Collector: RSS feed
-      Note over Collector: Normalize RSS items and generate dedupe_key.
+      Note over Collector: RSS item を正規化し、dedupe_key を生成する。
       Collector->>Article: POST /internal/ingest
-      Article->>DB: bulk upsert articles
+      Article->>DB: articles を bulk upsert
       Article-->>Collector: inserted_count, duplicated_count
       Collector->>Article: POST /internal/fetch-jobs/:id/finish success
-      Article->>DB: update fetch_jobs and source status
+      Article->>DB: fetch_jobs と source status を更新
       Article-->>Collector: 204 No Content
-    else RSS fetch or ingest fails
+    else RSS 取得または ingest が失敗
       Collector->>Article: POST /internal/fetch-jobs/:id/finish failed
-      Article->>DB: update fetch_jobs and source status
+      Article->>DB: fetch_jobs と source status を更新
       Article-->>Collector: 204 No Content
-      Note over Collector: Current implementation returns partial results<br/>and stops on the first error.
+      Note over Collector: 現在実装では partial results を返し、<br/>最初のエラーで処理を止める。
     end
   end
 
-  Collector-->>Caller: 202 Accepted or error response
+  Collector-->>Caller: 202 Accepted または error response
 ```
 
 ## 補足

--- a/docs/diagrams/article-collection-flow.md
+++ b/docs/diagrams/article-collection-flow.md
@@ -1,0 +1,66 @@
+# 記事収集フロー図
+
+この図は、`collector-service` が source 設定を取得してから、fetch job を開始し、RSS を正規化して `article-service` に ingest し、最後に job を完了させるまでの現在実装を示します。
+収集の主題は source 同期、逐次処理、job 管理、ingest 契約にあり、起動主体や将来の scheduler は図に含めていません。
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor Caller as External caller<br/>manual / API-triggered collection
+  participant Collector as collector-service
+  participant Article as article-service
+  participant RSS as External RSS source
+  participant DB as MySQL
+
+  Caller->>Collector: POST /api/v1/collect/run
+  Collector->>Article: GET /api/v1/sources
+  Article->>DB: read sources
+  DB-->>Article: source rows
+  Article-->>Collector: items
+  Note over Collector: Disabled sources are skipped.<br/>Enabled sources are processed sequentially.
+
+  loop each enabled source
+    Collector->>Article: POST /internal/fetch-jobs/start
+    Article->>DB: insert fetch_jobs(status=running)
+    Article-->>Collector: source_id, job_id
+
+    Collector->>RSS: GET fetch_url
+
+    alt RSS fetch and ingest succeed
+      RSS-->>Collector: RSS feed
+      Note over Collector: Normalize RSS items and generate dedupe_key.
+      Collector->>Article: POST /internal/ingest
+      Article->>DB: bulk upsert articles
+      Article-->>Collector: inserted_count, duplicated_count
+      Collector->>Article: POST /internal/fetch-jobs/{id}/finish success
+      Article->>DB: update fetch_jobs and source status
+      Article-->>Collector: 204 No Content
+    else RSS fetch or ingest fails
+      Collector->>Article: POST /internal/fetch-jobs/{id}/finish failed
+      Article->>DB: update fetch_jobs and source status
+      Article-->>Collector: 204 No Content
+      Note over Collector: Current implementation returns partial results<br/>and stops on the first error.
+    end
+  end
+
+  Collector-->>Caller: 202 Accepted or error response
+```
+
+## 補足
+
+- `collector-service` は `GET /api/v1/sources` の結果から `is_enabled=true` の source だけを対象にします。
+- `article-service` 側で `fetch_jobs` と `sources.last_fetch_status / last_error_message` を更新するため、source 詳細画面と job 履歴画面の整合が保たれます。
+- `article-service` は ingest 成功で `inserted_count > 0` のとき `article.ingested` を publish しますが、この図では主題を収集フローに絞っています。
+
+## repo からは未確定
+
+- 定期実行主体、retry / backoff、並列収集ポリシーは repo から確定できないため、この図には含めていません。
+
+## 主な根拠ファイル
+
+- `services/collector-service/internal/httpapi/routes.go`
+- `services/collector-service/internal/collector/service.go`
+- `services/article-service/internal/httpapi/router.go`
+- `services/article-service/internal/service/article_service.go`
+- `docs/openapi/article-service-internal.yaml`
+- `deployments/compose/mysql/init/001_schema.sql`

--- a/docs/diagrams/ci-test-lanes.md
+++ b/docs/diagrams/ci-test-lanes.md
@@ -7,7 +7,7 @@
 flowchart TD
   subgraph Triggers[トリガ]
     pr[pull_request]
-    push[push(main)]
+    push[push main]
     dispatch[workflow_dispatch]
   end
 
@@ -37,7 +37,7 @@ flowchart TD
   end
 
   subgraph Smoke[smoke]
-    smokeGate{docs_only ではなく<br/>push(main) / workflow_dispatch /<br/>e2e_relevant = true の PR か?}
+    smokeGate{docs_only ではなく<br/>push main / workflow_dispatch /<br/>e2e_relevant = true の PR か?}
     env[.env.example を .env にコピー]
     browsers[Playwright browsers を導入]
     e2eUp[make e2e-up]

--- a/docs/diagrams/ci-test-lanes.md
+++ b/docs/diagrams/ci-test-lanes.md
@@ -1,0 +1,96 @@
+# CI / テストレーン構成図
+
+この図は、GitHub Actions の test-related lanes に絞って、`changes` job の判定結果が `verify`、`integration`、`coverage`、`smoke` にどう影響するかを示します。
+通常のコード変更、docs-only 変更、E2E relevant change の違いを、repo 実装に即して把握できるようにしています。
+
+```mermaid
+flowchart TD
+  subgraph Triggers
+    pr[pull_request]
+    push[push main]
+    dispatch[workflow_dispatch]
+  end
+
+  subgraph Detection
+    changes[changes job<br/>detect docs_only and e2e_relevant]
+  end
+
+  subgraph Verify[verify]
+    verifyGate{docs_only?}
+    verifyRun[make verify]
+    verifySkip[skip heavy verification<br/>lightweight success]
+  end
+
+  subgraph Integration[integration]
+    integrationGate{docs_only?}
+    mysql[(MySQL service container)]
+    articleInt[make test-article-integration]
+    notificationInt[make test-notification-integration]
+    integrationSkip[skip integration]
+  end
+
+  subgraph Coverage[coverage]
+    coverageGate{docs_only?}
+    coverageRun[make test-frontend-coverage]
+    coverageArtifact[upload frontend coverage artifact]
+    coverageSkip[skip coverage]
+  end
+
+  subgraph Smoke[smoke]
+    smokeGate{docs_only != true and<br/>push main / workflow_dispatch /<br/>PR with e2e_relevant = true?}
+    env[cp .env.example .env]
+    browsers[install Playwright browsers]
+    e2eUp[make e2e-up]
+    e2eSeed[make e2e-seed]
+    e2eRun[make test-e2e]
+    report[upload Playwright report<br/>on failure]
+    e2eDown[make e2e-down]
+    smokeSkip[skip smoke]
+  end
+
+  pr --> changes
+  push --> changes
+  dispatch --> changes
+
+  changes --> verifyGate
+  changes --> integrationGate
+  changes --> coverageGate
+  changes --> smokeGate
+
+  verifyGate -- yes --> verifySkip
+  verifyGate -- no --> verifyRun
+
+  integrationGate -- yes --> integrationSkip
+  integrationGate -- no --> mysql --> articleInt --> notificationInt
+
+  coverageGate -- yes --> coverageSkip
+  coverageGate -- no --> coverageRun --> coverageArtifact
+
+  smokeGate -- no --> smokeSkip
+  smokeGate -- yes --> env --> browsers --> e2eUp --> e2eSeed --> e2eRun
+  e2eRun -->|failure only| report
+  e2eRun -->|always| e2eDown
+  report --> e2eDown
+```
+
+## 補足
+
+- `verify` は workflow 上は常に起動し、docs-only 変更では `make verify` を省略して軽量成功にします。
+- `integration` は MySQL service container 付きで article-service と notification-service の integration test を分離実行します。
+- `smoke` は docs-only 以外かつ `push main`、`workflow_dispatch`、または `e2e_relevant=true` の PR でだけ走ります。
+
+## repo からは未確定
+
+- branch protection や required checks の GitHub 設定は repo 外にあるため、この図には含めていません。
+
+## 主な根拠ファイル
+
+- `.github/workflows/ci.yml`
+- `Makefile`
+- `scripts/e2e/wait-for-stack.sh`
+- `scripts/e2e/seed.sh`
+- `frontend/playwright.config.ts`
+
+## 図に含めていないもの
+
+- `commit-message-check` と `pr-body-check` は別 workflow の PR guardrails のため、この図本体には含めていません。

--- a/docs/diagrams/ci-test-lanes.md
+++ b/docs/diagrams/ci-test-lanes.md
@@ -5,20 +5,20 @@
 
 ```mermaid
 flowchart TD
-  subgraph Triggers
+  subgraph Triggers[トリガ]
     pr[pull_request]
-    push[push main]
+    push[push(main)]
     dispatch[workflow_dispatch]
   end
 
-  subgraph Detection
-    changes[changes job<br/>detect docs_only and e2e_relevant]
+  subgraph Detection[変更判定]
+    changes[changes job<br/>docs_only と e2e_relevant を判定]
   end
 
   subgraph Verify[verify]
     verifyGate{docs_only?}
     verifyRun[make verify]
-    verifySkip[skip heavy verification<br/>lightweight success]
+    verifySkip[重い検証を省略<br/>軽量成功で完了]
   end
 
   subgraph Integration[integration]
@@ -26,26 +26,26 @@ flowchart TD
     mysql[(MySQL service container)]
     articleInt[make test-article-integration]
     notificationInt[make test-notification-integration]
-    integrationSkip[skip integration]
+    integrationSkip[integration を skip]
   end
 
   subgraph Coverage[coverage]
     coverageGate{docs_only?}
     coverageRun[make test-frontend-coverage]
-    coverageArtifact[upload frontend coverage artifact]
-    coverageSkip[skip coverage]
+    coverageArtifact[frontend coverage artifact を upload]
+    coverageSkip[coverage を skip]
   end
 
   subgraph Smoke[smoke]
-    smokeGate{docs_only != true and<br/>push main / workflow_dispatch /<br/>PR with e2e_relevant = true?}
-    env[cp .env.example .env]
-    browsers[install Playwright browsers]
+    smokeGate{docs_only ではなく<br/>push(main) / workflow_dispatch /<br/>e2e_relevant = true の PR か?}
+    env[.env.example を .env にコピー]
+    browsers[Playwright browsers を導入]
     e2eUp[make e2e-up]
     e2eSeed[make e2e-seed]
     e2eRun[make test-e2e]
-    report[upload Playwright report<br/>on failure]
+    report[失敗時に Playwright report を upload]
     e2eDown[make e2e-down]
-    smokeSkip[skip smoke]
+    smokeSkip[smoke を skip]
   end
 
   pr --> changes
@@ -57,19 +57,19 @@ flowchart TD
   changes --> coverageGate
   changes --> smokeGate
 
-  verifyGate -- yes --> verifySkip
-  verifyGate -- no --> verifyRun
+  verifyGate -- はい --> verifySkip
+  verifyGate -- いいえ --> verifyRun
 
-  integrationGate -- yes --> integrationSkip
-  integrationGate -- no --> mysql --> articleInt --> notificationInt
+  integrationGate -- はい --> integrationSkip
+  integrationGate -- いいえ --> mysql --> articleInt --> notificationInt
 
-  coverageGate -- yes --> coverageSkip
-  coverageGate -- no --> coverageRun --> coverageArtifact
+  coverageGate -- はい --> coverageSkip
+  coverageGate -- いいえ --> coverageRun --> coverageArtifact
 
-  smokeGate -- no --> smokeSkip
-  smokeGate -- yes --> env --> browsers --> e2eUp --> e2eSeed --> e2eRun
-  e2eRun -->|failure only| report
-  e2eRun -->|always| e2eDown
+  smokeGate -- いいえ --> smokeSkip
+  smokeGate -- はい --> env --> browsers --> e2eUp --> e2eSeed --> e2eRun
+  e2eRun -->|失敗時のみ| report
+  e2eRun -->|常に後処理| e2eDown
   report --> e2eDown
 ```
 

--- a/docs/diagrams/notification-generation-flow.md
+++ b/docs/diagrams/notification-generation-flow.md
@@ -1,0 +1,67 @@
+# 通知生成フロー図
+
+この図は、`article.ingested` と `collector.fetch.failed` が RabbitMQ を経由して `notification-service` に取り込まれ、通知一覧 API と既読更新 API を通じて UI に見えるまでの流れを示します。
+同期 API と非同期イベント処理の境界を分けて理解しやすくすることを目的にしています。
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant A as article-service publisher
+  participant C as collector-service publisher
+  participant MQ as RabbitMQ exchange<br/>tech-feed.events
+  participant N as notification-service consumer
+  participant DB as MySQL notifications
+  participant G as api-gateway
+  actor F as frontend / Browser
+
+  alt article.ingested
+    A->>MQ: publish article.ingested
+  else collector.fetch.failed
+    C->>MQ: publish collector.fetch.failed
+  end
+
+  MQ->>N: deliver event to notification-service consumer
+
+  alt event_type = article.ingested
+    N->>N: build info notification
+    N->>DB: insert notifications row
+  else event_type = collector.fetch.failed
+    N->>N: build error notification
+    N->>DB: insert notifications row
+  end
+
+  F->>G: GET /api/v1/notifications
+  G->>N: proxy /api/v1/notifications
+  N->>DB: select notifications
+  DB-->>N: notification rows
+  N-->>G: list response
+  G-->>F: list response
+
+  F->>G: PATCH /api/v1/notifications/{id}/read-status
+  G->>N: proxy read-status update
+  N->>DB: update is_read, read_at
+  DB-->>N: updated row
+  N-->>G: updated notification
+  G-->>F: updated notification
+```
+
+## 補足
+
+- `notification-service` は event の `event_type` を見て、`info` または `error` の通知レコードを生成します。
+- UI の公開導線は `frontend -> api-gateway -> notification-service` で、RabbitMQ は UI から直接は見えません。
+- 図では exchange と consumer を主題にしていますが、実装では `notification-service` queue を宣言し、`article.ingested` と `collector.fetch.failed` を bind しています。
+
+## repo からは未確定
+
+- dead-letter queue、max retry、複数 consumer、Slack / email / webhook などの配送先拡張は repo から確定できないため、この図には含めていません。
+
+## 主な根拠ファイル
+
+- `services/article-service/internal/events/publisher.go`
+- `services/collector-service/internal/events/publisher.go`
+- `services/notification-service/internal/events/contracts.go`
+- `services/notification-service/internal/events/consumer.go`
+- `services/notification-service/internal/service/notification_service.go`
+- `services/api-gateway/internal/httpapi/routes.go`
+- `docs/openapi/article.ingested.json`
+- `docs/openapi/collector.fetch.failed.json`

--- a/docs/diagrams/notification-generation-flow.md
+++ b/docs/diagrams/notification-generation-flow.md
@@ -6,40 +6,40 @@
 ```mermaid
 sequenceDiagram
   autonumber
-  participant A as article-service publisher
-  participant C as collector-service publisher
+  participant A as article-service 発行側
+  participant C as collector-service 発行側
   participant MQ as RabbitMQ exchange<br/>tech-feed.events
   participant N as notification-service consumer
   participant DB as MySQL notifications
   participant G as api-gateway
-  actor F as frontend / Browser
+  actor F as 利用者 / frontend
 
   alt article.ingested
-    A->>MQ: publish article.ingested
+    A->>MQ: article.ingested を publish
   else collector.fetch.failed
-    C->>MQ: publish collector.fetch.failed
+    C->>MQ: collector.fetch.failed を publish
   end
 
-  MQ->>N: deliver event to notification-service consumer
+  MQ->>N: event を consumer に配送
 
   alt event_type = article.ingested
-    N->>N: build info notification
-    N->>DB: insert notifications row
+    N->>N: info 通知を組み立てる
+    N->>DB: notifications 行を insert
   else event_type = collector.fetch.failed
-    N->>N: build error notification
-    N->>DB: insert notifications row
+    N->>N: error 通知を組み立てる
+    N->>DB: notifications 行を insert
   end
 
-  F->>G: GET /api/v1/notifications
-  G->>N: proxy /api/v1/notifications
-  N->>DB: select notifications
+  F->>G: 通知一覧を取得<br/>GET /api/v1/notifications
+  G->>N: /api/v1/notifications を proxy
+  N->>DB: notifications を取得
   DB-->>N: notification rows
   N-->>G: list response
   G-->>F: list response
 
-  F->>G: PATCH /api/v1/notifications/:id/read-status
-  G->>N: proxy read-status update
-  N->>DB: update is_read, read_at
+  F->>G: 既読状態を更新<br/>PATCH /api/v1/notifications/:id/read-status
+  G->>N: read-status update を proxy
+  N->>DB: is_read と read_at を更新
   DB-->>N: updated row
   N-->>G: updated notification
   G-->>F: updated notification

--- a/docs/diagrams/notification-generation-flow.md
+++ b/docs/diagrams/notification-generation-flow.md
@@ -37,7 +37,7 @@ sequenceDiagram
   N-->>G: list response
   G-->>F: list response
 
-  F->>G: PATCH /api/v1/notifications/{id}/read-status
+  F->>G: PATCH /api/v1/notifications/:id/read-status
   G->>N: proxy read-status update
   N->>DB: update is_read, read_at
   DB-->>N: updated row

--- a/docs/diagrams/system-overview.md
+++ b/docs/diagrams/system-overview.md
@@ -1,0 +1,71 @@
+# システム全体構成図
+
+この図は、現在の runtime 構成、公開 API 境界、内部連携、データ / メッセージ基盤を 1 枚で把握するためのものです。
+新規参入者や AI エージェントが、どの service がどこに依存し、どの経路が同期 API でどの経路が非同期イベントかを素早く掴めるようにしています。
+
+```mermaid
+flowchart LR
+  subgraph Client
+    user[Browser / User]
+    frontend[frontend<br/>React + TypeScript + Vite]
+  end
+
+  subgraph Public_API[Public API]
+    gateway[api-gateway<br/>/api/v1/*]
+  end
+
+  subgraph Processing
+    article[article-service]
+    collector[collector-service]
+    notification[notification-service]
+  end
+
+  subgraph Data_Messaging[Data and Messaging]
+    mysql[(MySQL<br/>articles / sources / fetch_jobs / notifications)]
+    rabbit[(RabbitMQ exchange<br/>tech-feed.events)]
+  end
+
+  subgraph External
+    rss[External RSS sources]
+  end
+
+  user --> frontend
+  frontend -->|HTTP /api/v1/*| gateway
+  gateway -->|articles / sources / fetch-jobs / CSV| article
+  gateway -->|notifications| notification
+
+  collector -->|GET /api/v1/sources| article
+  collector -->|POST /internal/fetch-jobs/start| article
+  collector -->|POST /internal/ingest| article
+  collector -->|POST /internal/fetch-jobs/{id}/finish| article
+  collector -->|GET fetch_url| rss
+
+  article -->|read and write| mysql
+  notification -->|read and write| mysql
+
+  article -->|publish article.ingested| rabbit
+  collector -->|publish collector.fetch.failed| rabbit
+  rabbit -->|consume events| notification
+```
+
+## 補足
+
+- `collector-service` は `frontend` や `api-gateway` の公開導線には入っておらず、別入口の収集実行 service として存在します。
+- `collector-service` は DB を直接触らず、`article-service` の public / internal API を使います。
+- `notification-service` は RabbitMQ の consumer であると同時に、通知一覧 / 既読更新 API の upstream でもあります。
+
+## repo からは未確定
+
+- `collector-service` の通常運用での起動主体は repo から確定できないため、この図では表現していません。
+
+## 主な根拠ファイル
+
+- `README.md`
+- `docker-compose.yml`
+- `services/api-gateway/internal/httpapi/routes.go`
+- `services/article-service/internal/app/app.go`
+- `services/collector-service/internal/app/app.go`
+- `services/collector-service/internal/collector/service.go`
+- `services/notification-service/internal/app/app.go`
+- `services/notification-service/internal/events/consumer.go`
+- `deployments/compose/mysql/init/001_schema.sql`

--- a/docs/diagrams/system-overview.md
+++ b/docs/diagrams/system-overview.md
@@ -5,47 +5,47 @@
 
 ```mermaid
 flowchart LR
-  subgraph Client
-    user[Browser / User]
-    frontend[frontend<br/>React + TypeScript + Vite]
+  subgraph Client[クライアント]
+    user[利用者 / Browser]
+    frontend[frontend<br/>UI<br/>React + TypeScript + Vite]
   end
 
-  subgraph Public_API[Public API]
-    gateway[api-gateway<br/>/api/v1/*]
+  subgraph Public_API[公開 API]
+    gateway[api-gateway<br/>公開 API /api/v1/*]
   end
 
-  subgraph Processing
+  subgraph Processing[処理系 service]
     article[article-service]
     collector[collector-service]
     notification[notification-service]
   end
 
-  subgraph Data_Messaging[Data and Messaging]
+  subgraph Data_Messaging[データ / メッセージ基盤]
     mysql[(MySQL<br/>articles / sources / fetch_jobs / notifications)]
     rabbit[(RabbitMQ exchange<br/>tech-feed.events)]
   end
 
-  subgraph External
-    rss[External RSS sources]
+  subgraph External[外部]
+    rss[外部 RSS sources]
   end
 
   user --> frontend
   frontend -->|HTTP /api/v1/*| gateway
-  gateway -->|articles / sources / fetch-jobs / CSV| article
-  gateway -->|notifications| notification
+  gateway -->|記事 / source / fetch-jobs / CSV| article
+  gateway -->|通知一覧 / 既読更新| notification
 
-  collector -->|GET /api/v1/sources| article
-  collector -->|POST /internal/fetch-jobs/start| article
-  collector -->|POST /internal/ingest| article
-  collector -->|POST /internal/fetch-jobs/:id/finish| article
-  collector -->|GET fetch_url| rss
+  collector -->|source 一覧取得<br/>GET /api/v1/sources| article
+  collector -->|fetch job 開始<br/>POST /internal/fetch-jobs/start| article
+  collector -->|ingest<br/>POST /internal/ingest| article
+  collector -->|fetch job 完了<br/>POST /internal/fetch-jobs/:id/finish| article
+  collector -->|RSS 取得<br/>GET fetch_url| rss
 
-  article -->|read and write| mysql
-  notification -->|read and write| mysql
+  article -->|読み書き| mysql
+  notification -->|読み書き| mysql
 
-  article -->|publish article.ingested| rabbit
-  collector -->|publish collector.fetch.failed| rabbit
-  rabbit -->|consume events| notification
+  article -->|article.ingested を publish| rabbit
+  collector -->|collector.fetch.failed を publish| rabbit
+  rabbit -->|event を consume| notification
 ```
 
 ## 補足

--- a/docs/diagrams/system-overview.md
+++ b/docs/diagrams/system-overview.md
@@ -37,7 +37,7 @@ flowchart LR
   collector -->|GET /api/v1/sources| article
   collector -->|POST /internal/fetch-jobs/start| article
   collector -->|POST /internal/ingest| article
-  collector -->|POST /internal/fetch-jobs/{id}/finish| article
+  collector -->|POST /internal/fetch-jobs/:id/finish| article
   collector -->|GET fetch_url| rss
 
   article -->|read and write| mysql

--- a/docs/test-policy.md
+++ b/docs/test-policy.md
@@ -135,6 +135,10 @@
 
 ## CI Expectations
 
+関連図:
+
+- [CI / テストレーン構成図](diagrams/ci-test-lanes.md)
+
 最低限 CI で回す対象:
 
 - backend test


### PR DESCRIPTION
## 概要

- ルート repo の現行実装を前提にした Mermaid 図ドキュメントを `docs/diagrams/` に追加
- README と関連 docs から図へ辿れる導線を追加
- GitHub 上での Mermaid パースエラーを解消し、可読性を落とさない範囲で日本語表記を調整

## 背景 / 目的

- README や docs から、アプリの全体像・主要処理・CI / テスト戦略を短時間で把握できるようにしたかった
- 新規参入者や AI エージェントが repo 構造を素早く理解できる入口を整えたかった
- 未実装の将来構成ではなく、現在の `main` 相当の実装実態に即した図を残したかった

## 変更内容

- `docs/diagrams/README.md` を追加し、図ドキュメントの index を作成
- 以下の 4 図を追加
- `system-overview.md`
- `article-collection-flow.md`
- `notification-generation-flow.md`
- `ci-test-lanes.md`
- `README.md` に図ドキュメントへの導線を追加
- `README.md` の `notification-service` 説明を現状実装に合わせて最小修正
- `docs/architecture.md` に構成図 / フロー図へのリンクを追加
- `docs/test-policy.md` に CI / テストレーン図へのリンクを追加
- `docs/agent-playbooks.md` に図ドキュメントへの導線を追加
- Mermaid のパースエラーを避けるため、`{id}` や `push(main)` など GitHub renderer で不安定だった表記を安全な記法へ修正
- 記事収集フロー図を中心に、残りの図も API 名や event 名を維持しつつ日本語寄りの表現へ調整

## 影響範囲

- frontend
- api-gateway
- collector-service
- article-service
- notification-service
- infra
- docs

実質的な変更対象は `docs` と `README` のみです。実装コード、Compose、workflow 定義自体には変更を入れていません。

## 検証

- [ ] `go test ./...`
- [ ] `npm run build`
- [ ] `docker compose config -q`
- [x] その他: `git diff --check`
- [x] その他: docs-only 変更としてリンク導線と Mermaid 記法の整合を確認

## API / DB / Infra への影響

- [ ] API を変更した
- [ ] DB schema を変更した
- [ ] Compose を変更した
- [ ] Kubernetes / Helm を変更した
- [x] 大きな影響はない

## ドキュメント

- [ ] 必要に応じて `RULES.md` を更新した
- [x] 関連する `docs/` を更新した
- [ ] ドキュメント更新は不要

## リスク / 注意点

- Mermaid renderer の実装差分で表示崩れが起きやすいため、記法は安全寄りに寄せています
- 今回の図は repo から断定できる情報だけに限定しており、未確定な起動主体や将来構成は注記に留めています
- `tech-news-hub/` 配下は今回の図対象に含めていません

## 補足

- `collector-service` の通常運用での起動主体は repo から確定できないため、図では `手動 / API-triggered collection` として抽象化しています
- `commit-message-check` と `pr-body-check` は別 workflow のため、CI / テストレーン図の本体には含めていません
- 変更ファイルは以下です
- `README.md`
- `docs/agent-playbooks.md`
- `docs/architecture.md`
- `docs/test-policy.md`
- `docs/diagrams/README.md`
- `docs/diagrams/system-overview.md`
- `docs/diagrams/article-collection-flow.md`
- `docs/diagrams/notification-generation-flow.md`
- `docs/diagrams/ci-test-lanes.md`
