### PR TITLE
docs: データモデル / 所有責務 ER 図を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ DevOps / インフラ / クラウド / SRE / CI/CD 関連の技術情報を定�
 
 ## Architecture And Diagrams
 
-- runtime 構成、記事収集、通知生成、CI / テストレーンの図は [図ドキュメント](docs/diagrams/README.md) から参照できます
+- runtime 構成、データモデル / 所有責務、記事収集、通知生成、CI / テストレーンの図は [図ドキュメント](docs/diagrams/README.md) から参照できます
 - 図は現行 repo 実装を根拠にしており、`tech-news-hub/` 配下や未実装の将来構成は含めていません
 
 ## Current Status

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,6 +26,7 @@
 ## Related Diagrams
 
 - [システム全体構成図](diagrams/system-overview.md)
+- [データモデル / 所有責務 ER 図](diagrams/data-model-ownership-er.md)
 - [記事収集フロー図](diagrams/article-collection-flow.md)
 - [通知生成フロー図](diagrams/notification-generation-flow.md)
 

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -1,7 +1,7 @@
 # 図ドキュメント
 
 このディレクトリには、ルート repo の現行実装を前提にした Mermaid 図をまとめています。
-README や個別 docs から辿れるようにし、runtime 構成、主要フロー、CI / テストレーンを短時間で把握できるようにするのが目的です。
+README や個別 docs から辿れるようにし、runtime 構成、データ構造、主要フロー、CI / テストレーンを短時間で把握できるようにするのが目的です。
 
 今回の図はこのルート repo を対象にしており、`tech-news-hub/` 配下は含めていません。
 また、kind / Helm / Argo CD、監視基盤、Redis など repo 上で未実装の将来要素は図に含めていません。
@@ -10,6 +10,8 @@ README や個別 docs から辿れるようにし、runtime 構成、主要フ�
 
 - [システム全体構成図](system-overview.md)
   - frontend、api-gateway、各 service、MySQL、RabbitMQ、外部 RSS の関係を示します。
+- [データモデル / 所有責務 ER 図](data-model-ownership-er.md)
+  - `sources`、`articles`、`fetch_jobs`、`notifications` の関係、FK / unique 制約、service ごとの所有責務を示します。
 - [記事収集フロー図](article-collection-flow.md)
   - `collector-service` が source 同期、fetch job 管理、RSS 正規化、ingest をどう進めるかを示します。
 - [通知生成フロー図](notification-generation-flow.md)

--- a/docs/diagrams/data-model-ownership-er.md
+++ b/docs/diagrams/data-model-ownership-er.md
@@ -1,0 +1,77 @@
+# データモデル / 所有責務 ER 図
+
+この図は、共有 MySQL 上にある `sources`、`articles`、`fetch_jobs`、`notifications` の関係を 1 枚で把握するためのものです。
+既存の runtime 図やフロー図とは分けて、静的なデータ構造、FK / unique 制約、service ごとの所有責務に絞っています。
+DB 変更レビュー時に、どのテーブルと制約に影響するかを短時間で確認しやすくすることを目的にしています。
+
+```mermaid
+erDiagram
+  sources ||--o{ articles : "source_id"
+  sources ||--o{ fetch_jobs : "source_id"
+  sources o|--o{ notifications : "source_id nullable"
+  fetch_jobs o|--o{ notifications : "fetch_job_id nullable"
+
+  sources {
+    BIGINT id PK
+    VARCHAR name UK "uq_sources_name"
+    VARCHAR default_category
+    BOOLEAN is_enabled
+    VARCHAR last_fetch_status
+    DATETIME last_fetched_at
+  }
+
+  articles {
+    BIGINT id PK
+    BIGINT source_id FK
+    VARCHAR dedupe_key UK "uq_articles_dedupe_key / idempotency key"
+    DATETIME published_at
+    DATETIME fetched_at
+    VARCHAR category
+    BOOLEAN is_read
+    BOOLEAN is_favorite
+  }
+
+  fetch_jobs {
+    BIGINT id PK
+    BIGINT source_id FK
+    VARCHAR status
+    DATETIME started_at
+    DATETIME finished_at
+    INT inserted_count
+    INT duplicated_count
+  }
+
+  notifications {
+    BIGINT id PK
+    VARCHAR event_id UK "uq_notifications_event_id / idempotency key"
+    VARCHAR event_type
+    BIGINT source_id FK "nullable"
+    BIGINT fetch_job_id FK "nullable"
+    VARCHAR level
+    BOOLEAN is_read
+    DATETIME read_at
+  }
+```
+
+## 所有責務の凡例
+
+- `article-service`: `sources`, `articles`, `fetch_jobs`
+- `notification-service`: `notifications`
+- 補足: 現在は共有 MySQL 上に共存しますが、`collector-service` は DB を直接更新せず `article-service` の public / internal API 経由で状態を変えます。
+
+## 補足
+
+- `articles.dedupe_key` は ingest 時の冪等性キーで、同一記事の重複登録を吸収します。
+- `notifications.event_id` は通知保存時の冪等性キーで、同一 event の重複保存を防ぎます。
+- `notifications.source_id` と `notifications.fetch_job_id` は schema 上 nullable FK で、通知種別ごとの差異を許容します。
+- 図本体からは外していますが、理解に効く index として `articles` の `FULLTEXT(title, excerpt)`、`fetch_jobs` の `(source_id, status, started_at, id)` があります。
+
+## 主な根拠ファイル
+
+- `deployments/compose/mysql/init/001_schema.sql`
+- `services/article-service/internal/repository/article_repository.go`
+- `services/article-service/internal/repository/source_repository.go`
+- `services/article-service/internal/repository/fetch_job_repository.go`
+- `services/notification-service/internal/repository/notification_repository.go`
+- `services/article-service/internal/service/article_service.go`
+- `services/notification-service/internal/service/notification_service.go`


### PR DESCRIPTION
## 概要

- `sources` / `articles` / `fetch_jobs` / `notifications` の関係を整理する ER 図を追加しました
- `article-service` と `notification-service` の所有責務を、既存の runtime / flow 図と重複しない形で明示しました
- 図ドキュメントへの導線を `README.md`、`docs/diagrams/README.md`、`docs/architecture.md` に最小限追加しました

## 背景 / 目的

- 既存図で runtime の大枠、収集フロー、通知フロー、CI / テストレーンは整理できていました
- 一方で、共有 MySQL 内の静的なデータ構造と service ごとの所有責務は図で把握しづらい状態でした
- DB 変更レビュー時に、どの制約とテーブルに影響するかを短時間で確認できるようにするため、静的構造に特化した図を追加します

## 変更内容

- `docs/diagrams/data-model-ownership-er.md` を追加しました
- 図では `sources`、`articles`、`fetch_jobs`、`notifications` の 4 entity を `erDiagram` で表現しました
- FK 関係、`uq_sources_name`、`uq_articles_dedupe_key`、`uq_notifications_event_id` を明示しました
- `notifications.source_id` / `fetch_job_id` の nullable FK を、関係線と列注記の両方で表現しました
- `articles.dedupe_key` と `notifications.event_id` を冪等性キーとして図と補足で説明しました
- 所有責務は Mermaid の色分けではなく、GitHub 表示の安定性を優先して凡例で表現しました

## 影響範囲

- docs
- 図ドキュメントの参照導線
- 実装コード、API、DB schema、Compose 構成への影響はありません

## 検証

- [ ] `go test ./...`
- [ ] `npm run build`
- [ ] `docker compose config -q`
- [x] その他: `git diff --check origin/main...HEAD`
- docs-only change のため、コード系検証は未実施です

## API / DB / Infra への影響

- [ ] API を変更した
- [ ] DB schema を変更した
- [ ] Compose を変更した
- [ ] Kubernetes / Helm を変更した
- [x] 大きな影響はない

## ドキュメント

- [ ] 必要に応じて `RULES.md` を更新した
- [x] 関連する `docs/` を更新した
- [ ] ドキュメント更新は不要

## リスク / 注意点

- 所有責務は色分けではなく凡例で表現しているため、将来図のデザイン方針が変わる場合は揃え直しが必要です
- Mermaid の実レンダリング自動確認はこの環境では行っておらず、GitHub の Mermaid 表示互換を前提にしています
- 本図は静的構造に限定しており、API 境界や runtime 実行方式は意図的に含めていません

## 補足

- `tech-news-hub/` 配下は今回の図対象に含めていません
- 今回は上位候補 3 図のうち、`データモデル / 所有責務 ER 図` のみを実装しています