### PR TITLE
docs: 公開 API / 内部 API 責務境界図を追加

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,6 +26,7 @@
 ## Related Diagrams
 
 - [システム全体構成図](diagrams/system-overview.md)
+- [公開 API / 内部 API 責務境界図](diagrams/api-boundary-public-internal.md)
 - [データモデル / 所有責務 ER 図](diagrams/data-model-ownership-er.md)
 - [記事収集フロー図](diagrams/article-collection-flow.md)
 - [通知生成フロー図](diagrams/notification-generation-flow.md)

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -16,6 +16,8 @@ README や個別 docs から辿れるようにし、runtime 構成、データ�
   - `collector-service` が source 同期、fetch job 管理、RSS 正規化、ingest をどう進めるかを示します。
 - [通知生成フロー図](notification-generation-flow.md)
   - `article.ingested` と `collector.fetch.failed` が通知一覧に見えるまでの非同期経路を示します。
+- [公開 API / 内部 API 責務境界図](api-boundary-public-internal.md)
+  - frontend route、`api-gateway` の公開 API group、upstream service の `/api/v1` と `article-service` の `/internal` 境界を示します。
 - [CI / テストレーン構成図](ci-test-lanes.md)
   - `changes -> verify / integration / coverage / smoke` の条件分岐と責務を示します。
 

--- a/docs/diagrams/api-boundary-public-internal.md
+++ b/docs/diagrams/api-boundary-public-internal.md
@@ -10,58 +10,58 @@ flowchart LR
   classDef internal fill:#fff7ed,stroke:#ea580c,color:#111827,stroke-width:1px;
   classDef collector fill:#f8fafc,stroke:#64748b,color:#111827,stroke-width:1px;
 
-  subgraph FE["Frontend Routes"]
+  subgraph FE["Frontend Routes / 画面 route"]
     direction TB
-    RHome["/<br/>article list / filters / CSV trigger"]
+    RHome["/<br/>記事一覧 / フィルタ / CSV 出力"]
     RArticle["/articles/:id"]
     RSources["/sources"]
     RSourceDetail["/sources/:id"]
     RNotifications["/notifications"]
   end
 
-  subgraph GW["Public API (Gateway /api/v1, mostly thin proxy)"]
+  subgraph GW["公開 API (Gateway /api/v1, ほぼ thin proxy)"]
     direction TB
-    GArticles["articles group<br/>GET /api/v1/articles<br/>GET /api/v1/articles/:id<br/>PATCH /api/v1/articles/:id/read-status<br/>PATCH /api/v1/articles/:id/favorite-status"]
-    GSources["sources group<br/>GET /api/v1/sources<br/>POST /api/v1/sources<br/>GET /api/v1/sources/:id<br/>PATCH /api/v1/sources/:id<br/>DELETE /api/v1/sources/:id<br/>GET /api/v1/fetch-jobs"]
-    GNotifications["notifications group<br/>GET /api/v1/notifications<br/>PATCH /api/v1/notifications/:id/read-status"]
-    GExports["CSV export exception<br/>GET /api/v1/exports/articles.csv"]
+    GArticles["記事 API group<br/>GET /api/v1/articles<br/>GET /api/v1/articles/:id<br/>PATCH /api/v1/articles/:id/read-status<br/>PATCH /api/v1/articles/:id/favorite-status"]
+    GSources["source API group<br/>GET /api/v1/sources<br/>POST /api/v1/sources<br/>GET /api/v1/sources/:id<br/>PATCH /api/v1/sources/:id<br/>DELETE /api/v1/sources/:id<br/>GET /api/v1/fetch-jobs"]
+    GNotifications["通知 API group<br/>GET /api/v1/notifications<br/>PATCH /api/v1/notifications/:id/read-status"]
+    GExports["CSV export 例外経路<br/>GET /api/v1/exports/articles.csv"]
   end
 
-  subgraph UP["Upstream Public APIs (/api/v1)"]
+  subgraph UP["Upstream 公開 API (/api/v1)"]
     direction TB
-    AArticles["article-service<br/>articles<br/>GET /api/v1/articles<br/>GET /api/v1/articles/:id<br/>PATCH /api/v1/articles/:id/read-status<br/>PATCH /api/v1/articles/:id/favorite-status"]
-    ASources["article-service<br/>sources + fetch-jobs<br/>GET /api/v1/sources<br/>POST /api/v1/sources<br/>GET /api/v1/sources/:id<br/>PATCH /api/v1/sources/:id<br/>DELETE /api/v1/sources/:id<br/>GET /api/v1/fetch-jobs"]
-    AExports["article-service<br/>exports<br/>GET /api/v1/articles/export.csv"]
-    NNotifications["notification-service<br/>notifications<br/>GET /api/v1/notifications<br/>PATCH /api/v1/notifications/:id/read-status"]
+    AArticles["article-service<br/>記事 API<br/>GET /api/v1/articles<br/>GET /api/v1/articles/:id<br/>PATCH /api/v1/articles/:id/read-status<br/>PATCH /api/v1/articles/:id/favorite-status"]
+    ASources["article-service<br/>source + fetch-jobs API<br/>GET /api/v1/sources<br/>POST /api/v1/sources<br/>GET /api/v1/sources/:id<br/>PATCH /api/v1/sources/:id<br/>DELETE /api/v1/sources/:id<br/>GET /api/v1/fetch-jobs"]
+    AExports["article-service<br/>export API<br/>GET /api/v1/articles/export.csv"]
+    NNotifications["notification-service<br/>通知 API<br/>GET /api/v1/notifications<br/>PATCH /api/v1/notifications/:id/read-status"]
   end
 
-  subgraph IN["Internal APIs (/internal)"]
+  subgraph IN["内部 API (/internal)"]
     direction TB
-    AInternal["article-service collector-only group<br/>POST /internal/fetch-jobs/start<br/>POST /internal/ingest<br/>POST /internal/fetch-jobs/:id/finish"]
+    AInternal["article-service collector 専用 group<br/>POST /internal/fetch-jobs/start<br/>POST /internal/ingest<br/>POST /internal/fetch-jobs/:id/finish"]
   end
 
-  subgraph COL["Collector Entry"]
+  subgraph COL["Collector Entry / 収集入口"]
     direction TB
-    CEntry["collector-service entry<br/>POST /api/v1/collect/run"]
-    CWorker["collector-service<br/>source sync + RSS fetch + normalize"]
+    CEntry["collector-service 入口<br/>POST /api/v1/collect/run"]
+    CWorker["collector-service<br/>source 同期 + RSS 取得 + 正規化"]
   end
 
-  RHome -->|list / search| GArticles
-  RHome -->|source filter options| GSources
-  RHome -->|CSV download| GExports
-  RArticle -->|detail + status update| GArticles
-  RSources -->|source list + save| GSources
-  RSourceDetail -->|source detail + fetch-jobs| GSources
-  RNotifications -->|list + read-status| GNotifications
+  RHome -->|一覧 / 検索| GArticles
+  RHome -->|source フィルタ候補| GSources
+  RHome -->|CSV 出力| GExports
+  RArticle -->|詳細 / 状態更新| GArticles
+  RSources -->|source 一覧 / 保存| GSources
+  RSourceDetail -->|source 詳細 / fetch-jobs| GSources
+  RNotifications -->|一覧 / 既読更新| GNotifications
 
   GArticles -->|proxy| AArticles
   GSources -->|proxy| ASources
   GNotifications -->|proxy| NNotifications
-  GExports -. path + download header adjusted in gateway .-> AExports
+  GExports -. gateway で path と download header を調整 .-> AExports
 
   CEntry --> CWorker
-  CWorker -->|load enabled sources| ASources
-  CWorker -->|start job / ingest / finish| AInternal
+  CWorker -->|enabled な source を取得| ASources
+  CWorker -->|job 開始 / ingest / job 完了| AInternal
 
   class RHome,RArticle,RSources,RSourceDetail,RNotifications route;
   class GArticles,GSources,GNotifications,GExports,AArticles,ASources,AExports,NNotifications public;
@@ -71,9 +71,9 @@ flowchart LR
 
 ## 補足
 
-- `api-gateway` は通常 `path / query / body / header` を upstream に渡す thin proxy で、CSV export だけ `GET /api/v1/exports/articles.csv -> GET /api/v1/articles/export.csv` と `Content-Disposition` 調整を行う例外です。
+- `api-gateway` は通常 `path / query / body / header` を upstream に渡す thin proxy で、CSV export だけ `GET /api/v1/exports/articles.csv -> GET /api/v1/articles/export.csv` と `Content-Disposition` の調整を行う例外です。
 - `collector-service` は通常閲覧導線とは別入口で、`GET /api/v1/sources` と `POST /internal/*` を使って `article-service` と連携します。
-- `Internal APIs (/internal)` は collector 連携用であり、frontend や `api-gateway` の公開導線には載せていません。
+- `内部 API (/internal)` は collector 連携用であり、frontend や `api-gateway` の公開導線には載せていません。
 
 ## 主な根拠ファイル
 

--- a/docs/diagrams/api-boundary-public-internal.md
+++ b/docs/diagrams/api-boundary-public-internal.md
@@ -1,0 +1,93 @@
+# 公開 API / 内部 API 責務境界図
+
+この図は、frontend の主要 route がどの公開 API group に依存し、その先で `api-gateway`、`article-service`、`notification-service`、`collector-service` がどこで責務分離されているかを 1 枚で把握するためのものです。
+通常閲覧導線と collector 導線を分けて示し、`/api/v1` と `/internal` の境界、CSV export の例外経路、OpenAPI 更新や service 境界逸脱の影響点を追いやすくします。
+
+```mermaid
+flowchart LR
+  classDef route fill:#eef2ff,stroke:#4f46e5,color:#111827,stroke-width:1px;
+  classDef public fill:#ecfeff,stroke:#0891b2,color:#111827,stroke-width:1px;
+  classDef internal fill:#fff7ed,stroke:#ea580c,color:#111827,stroke-width:1px;
+  classDef collector fill:#f8fafc,stroke:#64748b,color:#111827,stroke-width:1px;
+
+  subgraph FE["Frontend Routes"]
+    direction TB
+    RHome["/<br/>article list / filters / CSV trigger"]
+    RArticle["/articles/:id"]
+    RSources["/sources"]
+    RSourceDetail["/sources/:id"]
+    RNotifications["/notifications"]
+  end
+
+  subgraph GW["Public API (Gateway /api/v1, mostly thin proxy)"]
+    direction TB
+    GArticles["articles group<br/>GET /api/v1/articles<br/>GET /api/v1/articles/:id<br/>PATCH /api/v1/articles/:id/read-status<br/>PATCH /api/v1/articles/:id/favorite-status"]
+    GSources["sources group<br/>GET /api/v1/sources<br/>POST /api/v1/sources<br/>GET /api/v1/sources/:id<br/>PATCH /api/v1/sources/:id<br/>DELETE /api/v1/sources/:id<br/>GET /api/v1/fetch-jobs"]
+    GNotifications["notifications group<br/>GET /api/v1/notifications<br/>PATCH /api/v1/notifications/:id/read-status"]
+    GExports["CSV export exception<br/>GET /api/v1/exports/articles.csv"]
+  end
+
+  subgraph UP["Upstream Public APIs (/api/v1)"]
+    direction TB
+    AArticles["article-service<br/>articles<br/>GET /api/v1/articles<br/>GET /api/v1/articles/:id<br/>PATCH /api/v1/articles/:id/read-status<br/>PATCH /api/v1/articles/:id/favorite-status"]
+    ASources["article-service<br/>sources + fetch-jobs<br/>GET /api/v1/sources<br/>POST /api/v1/sources<br/>GET /api/v1/sources/:id<br/>PATCH /api/v1/sources/:id<br/>DELETE /api/v1/sources/:id<br/>GET /api/v1/fetch-jobs"]
+    AExports["article-service<br/>exports<br/>GET /api/v1/articles/export.csv"]
+    NNotifications["notification-service<br/>notifications<br/>GET /api/v1/notifications<br/>PATCH /api/v1/notifications/:id/read-status"]
+  end
+
+  subgraph IN["Internal APIs (/internal)"]
+    direction TB
+    AInternal["article-service collector-only group<br/>POST /internal/fetch-jobs/start<br/>POST /internal/ingest<br/>POST /internal/fetch-jobs/:id/finish"]
+  end
+
+  subgraph COL["Collector Entry"]
+    direction TB
+    CEntry["collector-service entry<br/>POST /api/v1/collect/run"]
+    CWorker["collector-service<br/>source sync + RSS fetch + normalize"]
+  end
+
+  RHome -->|list / search| GArticles
+  RHome -->|source filter options| GSources
+  RHome -->|CSV download| GExports
+  RArticle -->|detail + status update| GArticles
+  RSources -->|source list + save| GSources
+  RSourceDetail -->|source detail + fetch-jobs| GSources
+  RNotifications -->|list + read-status| GNotifications
+
+  GArticles -->|proxy| AArticles
+  GSources -->|proxy| ASources
+  GNotifications -->|proxy| NNotifications
+  GExports -. path + download header adjusted in gateway .-> AExports
+
+  CEntry --> CWorker
+  CWorker -->|load enabled sources| ASources
+  CWorker -->|start job / ingest / finish| AInternal
+
+  class RHome,RArticle,RSources,RSourceDetail,RNotifications route;
+  class GArticles,GSources,GNotifications,GExports,AArticles,ASources,AExports,NNotifications public;
+  class AInternal internal;
+  class CEntry,CWorker collector;
+```
+
+## 補足
+
+- `api-gateway` は通常 `path / query / body / header` を upstream に渡す thin proxy で、CSV export だけ `GET /api/v1/exports/articles.csv -> GET /api/v1/articles/export.csv` と `Content-Disposition` 調整を行う例外です。
+- `collector-service` は通常閲覧導線とは別入口で、`GET /api/v1/sources` と `POST /internal/*` を使って `article-service` と連携します。
+- `Internal APIs (/internal)` は collector 連携用であり、frontend や `api-gateway` の公開導線には載せていません。
+
+## 主な根拠ファイル
+
+- `frontend/src/main.tsx`
+- `frontend/src/lib/api.ts`
+- `frontend/src/ui/ArticleListPage.tsx`
+- `frontend/src/ui/ArticleDetailPage.tsx`
+- `frontend/src/ui/SourceManagementPage.tsx`
+- `frontend/src/ui/SourceDetailPage.tsx`
+- `frontend/src/ui/NotificationListPage.tsx`
+- `services/api-gateway/internal/httpapi/routes.go`
+- `services/article-service/internal/httpapi/router.go`
+- `services/collector-service/internal/httpapi/routes.go`
+- `services/collector-service/internal/collector/service.go`
+- `services/notification-service/internal/httpapi/router.go`
+- `docs/openapi/api-gateway.summary.md`
+- `docs/openapi/article-service-internal.yaml`


### PR DESCRIPTION
## 概要

- `docs/diagrams/api-boundary-public-internal.md` を追加し、frontend route と `api-gateway` / 各 service の API 境界を 1 枚で把握できるようにしました。
- `docs/diagrams/README.md` と `docs/architecture.md` に、この図への導線を最小限追加しました。

## 背景 / 目的

- 通常閲覧導線と collector 導線を分けて、`/api/v1` と `/internal` の責務境界を見やすくするためです。
- 変更時に、どの画面 / API group / upstream service が影響するかを追いやすくし、OpenAPI 更新漏れや service 境界逸脱の発見を助けるためです。

## 変更内容

- `docs/diagrams/api-boundary-public-internal.md` を新規追加しました。
- Mermaid は `flowchart LR` を使い、`Frontend Routes` -> `公開 API (Gateway /api/v1)` -> `Upstream 公開 API (/api/v1)` -> `内部 API (/internal)` の順で配置しました。
- route は `/`, `/articles/:id`, `/sources`, `/sources/:id`, `/notifications` を個別に記載しました。
- API は過密化を避けるため、`記事 API group`、`source API group`、`通知 API group`、`CSV export 例外経路`、`collector 専用 group` にまとめました。
- CSV export は通常 proxy とは別に、`GET /api/v1/exports/articles.csv` から `GET /api/v1/articles/export.csv` への例外経路として破線で表現しました。
- 図中ラベルは、service 名と path の識別性を残しつつ、日本語寄りに調整しました。
- `docs/diagrams/README.md` に図一覧を 1 件追加しました。
- `docs/architecture.md` の Related Diagrams にリンクを 1 件追加しました。

## 影響範囲

- frontend: route と参照 API group の可視化のみ
- api-gateway: 公開 API group と CSV export 例外経路の図示のみ
- collector-service: 入口と `article-service` 連携経路の図示のみ
- article-service: public / internal API 境界の図示のみ
- notification-service: notifications API group の図示のみ
- infra: なし
- docs: あり

## 検証

- [ ] `go test ./...`
- [ ] `npm run build`
- [ ] `docker compose config -q`
- [x] その他: docs-only 変更として、現行実装 (`frontend/src/main.tsx`, `frontend/src/lib/api.ts`, `services/*/internal/httpapi/*.go`, `services/collector-service/internal/collector/service.go`, `docs/openapi/*`) と差分を照合し、Mermaid 記述を目視確認

## API / DB / Infra への影響

- [ ] API を変更した
- [ ] DB schema を変更した
- [ ] Compose を変更した
- [ ] Kubernetes / Helm を変更した
- [x] 大きな影響はない

## ドキュメント

- [ ] 必要に応じて `RULES.md` を更新した
- [x] 関連する `docs/` を更新した
- [ ] ドキュメント更新は不要

## リスク / 注意点

- 図は現行実装準拠のため、今後 route や endpoint group を変更した場合は、この図と関連 OpenAPI / docs の同期が必要です。
- GitHub 上の Mermaid 表示は未確認です。記法は GitHub 互換を前提に記述しています。

## 補足

- 対象はルート repo の現行実装のみで、`tech-news-hub/` 配下や未実装の将来構成は含めていません。
- `api-gateway` は通常 thin proxy、CSV export だけが例外という前提を補足に明記しています。