### PR TITLE
Phase 5: umbrella Helm Chart と環境別 values の土台を追加

### DIFF
--- a/deployments/k8s/README.md
+++ b/deployments/k8s/README.md
@@ -1,3 +1,83 @@
-# Kubernetes Placeholder
+# Kubernetes Deployment Assets
 
-Phase 5 で Helm chart / values / Argo CD Application を追加します。
+`deployments/k8s/charts/app` に app 向け umbrella Helm chart を配置しています。
+
+## Directory Layout
+
+```text
+deployments/k8s/
+└── charts/app
+    ├── Chart.yaml
+    ├── values.yaml
+    ├── values-kind.yaml
+    ├── values-proxmox.yaml
+    └── templates/
+        ├── _helpers.tpl
+        ├── serviceaccount.yaml
+        ├── frontend.yaml
+        ├── api-gateway.yaml
+        ├── article-service.yaml
+        ├── collector-service.yaml
+        └── notification-service.yaml
+```
+
+## Scope
+
+- この chart は `frontend` / `api-gateway` / `article-service` / `collector-service` / `notification-service` をまとめて扱う app-only の umbrella chart です
+- MySQL / RabbitMQ はこの issue ではインストール対象に含めません
+- DB / AMQP の接続情報は既存 Secret 参照として values から受け取ります
+- collector は現状どおり `Deployment` として扱い、`schedule` は CronJob 化に備えた予約値です
+
+## Values Responsibility
+
+### `values.yaml`
+
+- chart の共通インターフェースを定義します
+- 5 サービスの `enabled`、`image`、`service.port`、`ingress`、`resources`、`replicaCount`、probe を揃えます
+- `global.dependencies` に app 間 URL と `MYSQL_DSN` / `AMQP_URL` の Secret 参照をまとめます
+- `global.persistence` には Phase 6 で infra chart または external dependency に接続するときに使う差分の受け皿を置きます
+- `article-service` や `notification-service` を無効化したまま依存先だけ残す場合は `global.dependencies.articleServiceUrl` / `global.dependencies.notificationServiceUrl` を外部 endpoint へ上書きします
+
+### `values-kind.yaml`
+
+- kind での最小検証向けの差分だけを置きます
+- ローカル読み込み前提の image repository / tag / pull policy
+- kind 用 ingress host
+- 低めの replica / resource
+- kind 側 Secret 名と storage class の差分
+
+### `values-proxmox.yaml`
+
+- Proxmox 実クラスタ移行を見据えた registry-aware な差分を置きます
+- registry pull を前提にした image repository / tag / `global.imagePullSecrets`
+- host / TLS / replica / resource の本番寄り差分
+- Proxmox 側 Secret 名と storage class の差分
+
+## Secret Boundary
+
+- Secret の実値は values に入れません
+- `global.dependencies.mysql.secretRef` は `MYSQL_DSN` を保持する Secret を指します
+- `global.dependencies.rabbitmq.secretRef` は `AMQP_URL` を保持する Secret を指します
+- 環境差分では Secret 名や key を上書きし、値そのものは cluster 側で供給します
+
+## Render And Verify
+
+```bash
+helm lint deployments/k8s/charts/app
+helm template tech-feed-hub deployments/k8s/charts/app \
+  -f deployments/k8s/charts/app/values.yaml \
+  -f deployments/k8s/charts/app/values-kind.yaml
+helm template tech-feed-hub deployments/k8s/charts/app \
+  -f deployments/k8s/charts/app/values.yaml \
+  -f deployments/k8s/charts/app/values-proxmox.yaml
+```
+
+## Phase 6 Expected Additions
+
+Phase 6 では次の差分を values 追加で吸収しやすい構成を維持します。
+
+- `storageClass` の具体化
+- TLS 証明書の実運用値
+- `nodeSelector` / `tolerations` / `affinity`
+- infra chart 側の persistence 連携
+- Secret 供給方式の external secret 化

--- a/deployments/k8s/charts/app/Chart.yaml
+++ b/deployments/k8s/charts/app/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: tech-feed-hub-app
+description: Umbrella Helm chart for Tech Feed Hub application services.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/deployments/k8s/charts/app/templates/_helpers.tpl
+++ b/deployments/k8s/charts/app/templates/_helpers.tpl
@@ -1,0 +1,104 @@
+{{- define "tech-feed-hub.name" -}}
+{{- default .Chart.Name .Values.global.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "tech-feed-hub.fullname" -}}
+{{- $name := default .Chart.Name .Values.global.nameOverride -}}
+{{- if .Values.global.fullnameOverride -}}
+{{- .Values.global.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "tech-feed-hub.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "tech-feed-hub.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tech-feed-hub.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "tech-feed-hub.labels" -}}
+helm.sh/chart: {{ include "tech-feed-hub.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: tech-feed-hub
+{{ include "tech-feed-hub.selectorLabels" . }}
+{{- end -}}
+
+{{- define "tech-feed-hub.componentFullname" -}}
+{{- printf "%s-%s" (include "tech-feed-hub.fullname" .root) .component | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "tech-feed-hub.componentSelectorLabels" -}}
+{{ include "tech-feed-hub.selectorLabels" .root }}
+app.kubernetes.io/component: {{ .component }}
+{{- end -}}
+
+{{- define "tech-feed-hub.componentLabels" -}}
+{{ include "tech-feed-hub.labels" .root }}
+app.kubernetes.io/component: {{ .component }}
+{{- end -}}
+
+{{- define "tech-feed-hub.serviceAccountName" -}}
+{{- if .Values.global.serviceAccount.create -}}
+{{- default (include "tech-feed-hub.fullname" .) .Values.global.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.global.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "tech-feed-hub.imagePullSecrets" -}}
+{{- $global := .root.Values.global.imagePullSecrets | default (list) -}}
+{{- $local := .service.imagePullSecrets | default (list) -}}
+{{- $all := concat $global $local -}}
+{{- if gt (len $all) 0 }}
+imagePullSecrets:
+{{- range $all }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "tech-feed-hub.httpProbe" -}}
+httpGet:
+  path: {{ .path | quote }}
+  port: http
+initialDelaySeconds: {{ default 5 .initialDelaySeconds }}
+periodSeconds: {{ default 10 .periodSeconds }}
+timeoutSeconds: {{ default 2 .timeoutSeconds }}
+failureThreshold: {{ default 3 .failureThreshold }}
+{{- end -}}
+
+{{- define "tech-feed-hub.extraEnv" -}}
+{{- range . }}
+- name: {{ .name }}
+  value: {{ .value | quote }}
+{{- end }}
+{{- end -}}
+
+{{- define "tech-feed-hub.extraSecretEnv" -}}
+{{- range . }}
+- name: {{ .name }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .secretName }}
+      key: {{ .secretKey }}
+      optional: {{ default false .optional }}
+{{- end }}
+{{- end -}}
+
+{{- define "tech-feed-hub.apiGatewayUrl" -}}
+{{- printf "http://%s:%v" (include "tech-feed-hub.componentFullname" (dict "root" . "component" "api-gateway")) .Values.services.apiGateway.service.port -}}
+{{- end -}}
+
+{{- define "tech-feed-hub.articleServiceUrl" -}}
+{{- printf "http://%s:%v" (include "tech-feed-hub.componentFullname" (dict "root" . "component" "article-service")) .Values.services.articleService.service.port -}}
+{{- end -}}
+
+{{- define "tech-feed-hub.notificationServiceUrl" -}}
+{{- printf "http://%s:%v" (include "tech-feed-hub.componentFullname" (dict "root" . "component" "notification-service")) .Values.services.notificationService.service.port -}}
+{{- end -}}

--- a/deployments/k8s/charts/app/templates/api-gateway.yaml
+++ b/deployments/k8s/charts/app/templates/api-gateway.yaml
@@ -1,0 +1,125 @@
+{{- $root := . -}}
+{{- $service := .Values.services.apiGateway -}}
+{{- if $service.enabled }}
+{{- $component := "api-gateway" -}}
+{{- $name := include "tech-feed-hub.componentFullname" (dict "root" $root "component" $component) -}}
+{{- $articleServiceUrl := default (include "tech-feed-hub.articleServiceUrl" $root) $root.Values.global.dependencies.articleServiceUrl -}}
+{{- $notificationServiceUrl := default (include "tech-feed-hub.notificationServiceUrl" $root) $root.Values.global.dependencies.notificationServiceUrl -}}
+{{- $ingressAnnotations := mergeOverwrite (dict) ($root.Values.global.ingress.annotations | default dict) ($service.ingress.annotations | default dict) -}}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "tech-feed-hub.componentLabels" (dict "root" $root "component" $component) | nindent 4 }}
+    {{- with $service.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  replicas: {{ $service.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "tech-feed-hub.componentSelectorLabels" (dict "root" $root "component" $component) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "tech-feed-hub.componentSelectorLabels" (dict "root" $root "component" $component) | nindent 8 }}
+        {{- with $service.extraLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with $service.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "tech-feed-hub.serviceAccountName" $root }}
+      {{- include "tech-feed-hub.imagePullSecrets" (dict "root" $root "service" $service) | nindent 6 }}
+      containers:
+        - name: {{ $component }}
+          image: "{{ $service.image.repository }}:{{ $service.image.tag }}"
+          imagePullPolicy: {{ $service.image.pullPolicy }}
+          {{- with $service.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $service.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ $service.containerPort }}
+          env:
+            - name: PORT
+              value: {{ printf "%v" $service.containerPort | quote }}
+            - name: ARTICLE_SERVICE_URL
+              value: {{ $articleServiceUrl | quote }}
+            - name: NOTIFICATION_SERVICE_URL
+              value: {{ $notificationServiceUrl | quote }}
+            - name: JWT_SECRET
+              value: {{ $service.config.jwtSecret | quote }}
+            {{- with $service.extraEnv }}
+            {{- include "tech-feed-hub.extraEnv" . | nindent 12 }}
+            {{- end }}
+            {{- with $service.extraSecretEnv }}
+            {{- include "tech-feed-hub.extraSecretEnv" . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            {{- include "tech-feed-hub.httpProbe" $service.probes.liveness | nindent 12 }}
+          readinessProbe:
+            {{- include "tech-feed-hub.httpProbe" $service.probes.readiness | nindent 12 }}
+          {{- with $service.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "tech-feed-hub.componentLabels" (dict "root" $root "component" $component) | nindent 4 }}
+spec:
+  type: {{ $service.service.type }}
+  selector:
+    {{- include "tech-feed-hub.componentSelectorLabels" (dict "root" $root "component" $component) | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ $service.service.port }}
+      targetPort: http
+{{- if $service.ingress.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "tech-feed-hub.componentLabels" (dict "root" $root "component" $component) | nindent 4 }}
+  {{- if $ingressAnnotations }}
+  annotations:
+    {{- toYaml $ingressAnnotations | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ default $root.Values.global.ingress.className $service.ingress.className }}
+  rules:
+    {{- range $service.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path | quote }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $name }}
+                port:
+                  number: {{ $service.service.port }}
+          {{- end }}
+    {{- end }}
+  {{- with $service.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/deployments/k8s/charts/app/templates/article-service.yaml
+++ b/deployments/k8s/charts/app/templates/article-service.yaml
@@ -1,0 +1,94 @@
+{{- $root := . -}}
+{{- $service := .Values.services.articleService -}}
+{{- if $service.enabled }}
+{{- $component := "article-service" -}}
+{{- $name := include "tech-feed-hub.componentFullname" (dict "root" $root "component" $component) -}}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "tech-feed-hub.componentLabels" (dict "root" $root "component" $component) | nindent 4 }}
+    {{- with $service.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  replicas: {{ $service.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "tech-feed-hub.componentSelectorLabels" (dict "root" $root "component" $component) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "tech-feed-hub.componentSelectorLabels" (dict "root" $root "component" $component) | nindent 8 }}
+        {{- with $service.extraLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with $service.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "tech-feed-hub.serviceAccountName" $root }}
+      {{- include "tech-feed-hub.imagePullSecrets" (dict "root" $root "service" $service) | nindent 6 }}
+      containers:
+        - name: {{ $component }}
+          image: "{{ $service.image.repository }}:{{ $service.image.tag }}"
+          imagePullPolicy: {{ $service.image.pullPolicy }}
+          {{- with $service.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $service.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ $service.containerPort }}
+          env:
+            - name: PORT
+              value: {{ printf "%v" $service.containerPort | quote }}
+            - name: MYSQL_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $root.Values.global.dependencies.mysql.secretRef.name }}
+                  key: {{ $root.Values.global.dependencies.mysql.secretRef.key }}
+            - name: AMQP_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $root.Values.global.dependencies.rabbitmq.secretRef.name }}
+                  key: {{ $root.Values.global.dependencies.rabbitmq.secretRef.key }}
+            - name: AMQP_EXCHANGE
+              value: {{ $root.Values.global.dependencies.rabbitmq.exchange | quote }}
+            {{- with $service.extraEnv }}
+            {{- include "tech-feed-hub.extraEnv" . | nindent 12 }}
+            {{- end }}
+            {{- with $service.extraSecretEnv }}
+            {{- include "tech-feed-hub.extraSecretEnv" . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            {{- include "tech-feed-hub.httpProbe" $service.probes.liveness | nindent 12 }}
+          readinessProbe:
+            {{- include "tech-feed-hub.httpProbe" $service.probes.readiness | nindent 12 }}
+          {{- with $service.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "tech-feed-hub.componentLabels" (dict "root" $root "component" $component) | nindent 4 }}
+spec:
+  type: {{ $service.service.type }}
+  selector:
+    {{- include "tech-feed-hub.componentSelectorLabels" (dict "root" $root "component" $component) | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ $service.service.port }}
+      targetPort: http
+{{- end }}

--- a/deployments/k8s/charts/app/templates/collector-service.yaml
+++ b/deployments/k8s/charts/app/templates/collector-service.yaml
@@ -1,0 +1,92 @@
+{{- $root := . -}}
+{{- $service := .Values.services.collectorService -}}
+{{- if $service.enabled }}
+{{- $component := "collector-service" -}}
+{{- $name := include "tech-feed-hub.componentFullname" (dict "root" $root "component" $component) -}}
+{{- $articleServiceUrl := default (include "tech-feed-hub.articleServiceUrl" $root) $root.Values.global.dependencies.articleServiceUrl -}}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "tech-feed-hub.componentLabels" (dict "root" $root "component" $component) | nindent 4 }}
+    {{- with $service.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  replicas: {{ $service.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "tech-feed-hub.componentSelectorLabels" (dict "root" $root "component" $component) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "tech-feed-hub.componentSelectorLabels" (dict "root" $root "component" $component) | nindent 8 }}
+        {{- with $service.extraLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with $service.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "tech-feed-hub.serviceAccountName" $root }}
+      {{- include "tech-feed-hub.imagePullSecrets" (dict "root" $root "service" $service) | nindent 6 }}
+      containers:
+        - name: {{ $component }}
+          image: "{{ $service.image.repository }}:{{ $service.image.tag }}"
+          imagePullPolicy: {{ $service.image.pullPolicy }}
+          {{- with $service.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $service.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ $service.containerPort }}
+          env:
+            - name: PORT
+              value: {{ printf "%v" $service.containerPort | quote }}
+            - name: ARTICLE_SERVICE_URL
+              value: {{ $articleServiceUrl | quote }}
+            - name: AMQP_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $root.Values.global.dependencies.rabbitmq.secretRef.name }}
+                  key: {{ $root.Values.global.dependencies.rabbitmq.secretRef.key }}
+            - name: AMQP_EXCHANGE
+              value: {{ $root.Values.global.dependencies.rabbitmq.exchange | quote }}
+            {{- with $service.extraEnv }}
+            {{- include "tech-feed-hub.extraEnv" . | nindent 12 }}
+            {{- end }}
+            {{- with $service.extraSecretEnv }}
+            {{- include "tech-feed-hub.extraSecretEnv" . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            {{- include "tech-feed-hub.httpProbe" $service.probes.liveness | nindent 12 }}
+          readinessProbe:
+            {{- include "tech-feed-hub.httpProbe" $service.probes.readiness | nindent 12 }}
+          {{- with $service.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "tech-feed-hub.componentLabels" (dict "root" $root "component" $component) | nindent 4 }}
+spec:
+  type: {{ $service.service.type }}
+  selector:
+    {{- include "tech-feed-hub.componentSelectorLabels" (dict "root" $root "component" $component) | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ $service.service.port }}
+      targetPort: http
+{{- end }}

--- a/deployments/k8s/charts/app/templates/frontend.yaml
+++ b/deployments/k8s/charts/app/templates/frontend.yaml
@@ -1,0 +1,120 @@
+{{- $root := . -}}
+{{- $service := .Values.services.frontend -}}
+{{- if $service.enabled }}
+{{- $component := "frontend" -}}
+{{- $name := include "tech-feed-hub.componentFullname" (dict "root" $root "component" $component) -}}
+{{- $proxyTarget := default (include "tech-feed-hub.apiGatewayUrl" $root) $service.config.proxyTarget -}}
+{{- $ingressAnnotations := mergeOverwrite (dict) ($root.Values.global.ingress.annotations | default dict) ($service.ingress.annotations | default dict) -}}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "tech-feed-hub.componentLabels" (dict "root" $root "component" $component) | nindent 4 }}
+    {{- with $service.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  replicas: {{ $service.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "tech-feed-hub.componentSelectorLabels" (dict "root" $root "component" $component) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "tech-feed-hub.componentSelectorLabels" (dict "root" $root "component" $component) | nindent 8 }}
+        {{- with $service.extraLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with $service.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "tech-feed-hub.serviceAccountName" $root }}
+      {{- include "tech-feed-hub.imagePullSecrets" (dict "root" $root "service" $service) | nindent 6 }}
+      containers:
+        - name: {{ $component }}
+          image: "{{ $service.image.repository }}:{{ $service.image.tag }}"
+          imagePullPolicy: {{ $service.image.pullPolicy }}
+          {{- with $service.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $service.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ $service.containerPort }}
+          env:
+            - name: VITE_API_BASE_URL
+              value: {{ $service.config.apiBaseUrl | quote }}
+            - name: VITE_PROXY_TARGET
+              value: {{ $proxyTarget | quote }}
+            {{- with $service.extraEnv }}
+            {{- include "tech-feed-hub.extraEnv" . | nindent 12 }}
+            {{- end }}
+            {{- with $service.extraSecretEnv }}
+            {{- include "tech-feed-hub.extraSecretEnv" . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            {{- include "tech-feed-hub.httpProbe" $service.probes.liveness | nindent 12 }}
+          readinessProbe:
+            {{- include "tech-feed-hub.httpProbe" $service.probes.readiness | nindent 12 }}
+          {{- with $service.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "tech-feed-hub.componentLabels" (dict "root" $root "component" $component) | nindent 4 }}
+spec:
+  type: {{ $service.service.type }}
+  selector:
+    {{- include "tech-feed-hub.componentSelectorLabels" (dict "root" $root "component" $component) | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ $service.service.port }}
+      targetPort: http
+{{- if $service.ingress.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "tech-feed-hub.componentLabels" (dict "root" $root "component" $component) | nindent 4 }}
+  {{- if $ingressAnnotations }}
+  annotations:
+    {{- toYaml $ingressAnnotations | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ default $root.Values.global.ingress.className $service.ingress.className }}
+  rules:
+    {{- range $service.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path | quote }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $name }}
+                port:
+                  number: {{ $service.service.port }}
+          {{- end }}
+    {{- end }}
+  {{- with $service.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/deployments/k8s/charts/app/templates/notification-service.yaml
+++ b/deployments/k8s/charts/app/templates/notification-service.yaml
@@ -1,0 +1,96 @@
+{{- $root := . -}}
+{{- $service := .Values.services.notificationService -}}
+{{- if $service.enabled }}
+{{- $component := "notification-service" -}}
+{{- $name := include "tech-feed-hub.componentFullname" (dict "root" $root "component" $component) -}}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "tech-feed-hub.componentLabels" (dict "root" $root "component" $component) | nindent 4 }}
+    {{- with $service.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  replicas: {{ $service.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "tech-feed-hub.componentSelectorLabels" (dict "root" $root "component" $component) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "tech-feed-hub.componentSelectorLabels" (dict "root" $root "component" $component) | nindent 8 }}
+        {{- with $service.extraLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with $service.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "tech-feed-hub.serviceAccountName" $root }}
+      {{- include "tech-feed-hub.imagePullSecrets" (dict "root" $root "service" $service) | nindent 6 }}
+      containers:
+        - name: {{ $component }}
+          image: "{{ $service.image.repository }}:{{ $service.image.tag }}"
+          imagePullPolicy: {{ $service.image.pullPolicy }}
+          {{- with $service.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $service.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ $service.containerPort }}
+          env:
+            - name: PORT
+              value: {{ printf "%v" $service.containerPort | quote }}
+            - name: MYSQL_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $root.Values.global.dependencies.mysql.secretRef.name }}
+                  key: {{ $root.Values.global.dependencies.mysql.secretRef.key }}
+            - name: AMQP_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $root.Values.global.dependencies.rabbitmq.secretRef.name }}
+                  key: {{ $root.Values.global.dependencies.rabbitmq.secretRef.key }}
+            - name: AMQP_EXCHANGE
+              value: {{ $root.Values.global.dependencies.rabbitmq.exchange | quote }}
+            - name: AMQP_QUEUE_NAME
+              value: {{ $root.Values.global.dependencies.rabbitmq.queueName | quote }}
+            {{- with $service.extraEnv }}
+            {{- include "tech-feed-hub.extraEnv" . | nindent 12 }}
+            {{- end }}
+            {{- with $service.extraSecretEnv }}
+            {{- include "tech-feed-hub.extraSecretEnv" . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            {{- include "tech-feed-hub.httpProbe" $service.probes.liveness | nindent 12 }}
+          readinessProbe:
+            {{- include "tech-feed-hub.httpProbe" $service.probes.readiness | nindent 12 }}
+          {{- with $service.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "tech-feed-hub.componentLabels" (dict "root" $root "component" $component) | nindent 4 }}
+spec:
+  type: {{ $service.service.type }}
+  selector:
+    {{- include "tech-feed-hub.componentSelectorLabels" (dict "root" $root "component" $component) | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ $service.service.port }}
+      targetPort: http
+{{- end }}

--- a/deployments/k8s/charts/app/templates/serviceaccount.yaml
+++ b/deployments/k8s/charts/app/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.global.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tech-feed-hub.serviceAccountName" . }}
+  labels:
+    {{- include "tech-feed-hub.labels" . | nindent 4 }}
+  {{- with .Values.global.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deployments/k8s/charts/app/values-kind.yaml
+++ b/deployments/k8s/charts/app/values-kind.yaml
@@ -1,0 +1,96 @@
+global:
+  ingress:
+    className: nginx
+  imagePullSecrets: []
+  dependencies:
+    mysql:
+      secretRef:
+        name: tech-feed-hub-kind-secrets
+        key: MYSQL_DSN
+    rabbitmq:
+      secretRef:
+        name: tech-feed-hub-kind-secrets
+        key: AMQP_URL
+  persistence:
+    mysql:
+      storageClass: standard
+    rabbitmq:
+      storageClass: standard
+
+services:
+  frontend:
+    image:
+      repository: tech-feed-hub/frontend
+      tag: kind
+      pullPolicy: IfNotPresent
+    ingress:
+      hosts:
+        - host: tech-feed-hub.kind.local
+          paths:
+            - path: /
+              pathType: Prefix
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
+
+  apiGateway:
+    image:
+      repository: tech-feed-hub/api-gateway
+      tag: kind
+      pullPolicy: IfNotPresent
+    ingress:
+      hosts:
+        - host: api.tech-feed-hub.kind.local
+          paths:
+            - path: /
+              pathType: Prefix
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 250m
+        memory: 256Mi
+
+  articleService:
+    image:
+      repository: tech-feed-hub/article-service
+      tag: kind
+      pullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 300m
+        memory: 256Mi
+
+  collectorService:
+    image:
+      repository: tech-feed-hub/collector-service
+      tag: kind
+      pullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 250m
+        memory: 192Mi
+
+  notificationService:
+    image:
+      repository: tech-feed-hub/notification-service
+      tag: kind
+      pullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 75m
+        memory: 96Mi
+      limits:
+        cpu: 250m
+        memory: 256Mi

--- a/deployments/k8s/charts/app/values-proxmox.yaml
+++ b/deployments/k8s/charts/app/values-proxmox.yaml
@@ -1,0 +1,109 @@
+global:
+  ingress:
+    className: nginx
+  imagePullSecrets:
+    - ghcr-creds
+  dependencies:
+    mysql:
+      secretRef:
+        name: tech-feed-hub-proxmox-secrets
+        key: MYSQL_DSN
+    rabbitmq:
+      secretRef:
+        name: tech-feed-hub-proxmox-secrets
+        key: AMQP_URL
+  persistence:
+    mysql:
+      storageClass: ceph-block
+    rabbitmq:
+      storageClass: ceph-block
+
+services:
+  frontend:
+    replicaCount: 2
+    image:
+      repository: ghcr.io/syuhei0519/tech-news-hub/frontend
+      tag: main
+      pullPolicy: IfNotPresent
+    ingress:
+      hosts:
+        - host: tech-feed-hub.home.arpa
+          paths:
+            - path: /
+              pathType: Prefix
+      tls:
+        - secretName: tech-feed-hub-home-arpa-tls
+          hosts:
+            - tech-feed-hub.home.arpa
+    resources:
+      requests:
+        cpu: 100m
+        memory: 192Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+  apiGateway:
+    replicaCount: 2
+    image:
+      repository: ghcr.io/syuhei0519/tech-news-hub/api-gateway
+      tag: main
+      pullPolicy: IfNotPresent
+    ingress:
+      hosts:
+        - host: api.tech-feed-hub.home.arpa
+          paths:
+            - path: /
+              pathType: Prefix
+      tls:
+        - secretName: api-tech-feed-hub-home-arpa-tls
+          hosts:
+            - api.tech-feed-hub.home.arpa
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+  articleService:
+    replicaCount: 2
+    image:
+      repository: ghcr.io/syuhei0519/tech-news-hub/article-service
+      tag: main
+      pullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256Mi
+      limits:
+        cpu: 750m
+        memory: 768Mi
+
+  collectorService:
+    image:
+      repository: ghcr.io/syuhei0519/tech-news-hub/collector-service
+      tag: main
+      pullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+  notificationService:
+    replicaCount: 2
+    image:
+      repository: ghcr.io/syuhei0519/tech-news-hub/notification-service
+      tag: main
+      pullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 150m
+        memory: 192Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi

--- a/deployments/k8s/charts/app/values.yaml
+++ b/deployments/k8s/charts/app/values.yaml
@@ -1,0 +1,245 @@
+global:
+  nameOverride: tech-feed-hub
+  fullnameOverride: ""
+  imagePullSecrets: []
+  serviceAccount:
+    create: true
+    annotations: {}
+    name: ""
+  ingress:
+    className: nginx
+    annotations: {}
+  dependencies:
+    articleServiceUrl: ""
+    notificationServiceUrl: ""
+    mysql:
+      secretRef:
+        name: tech-feed-hub-app-secrets
+        key: MYSQL_DSN
+    rabbitmq:
+      secretRef:
+        name: tech-feed-hub-app-secrets
+        key: AMQP_URL
+      exchange: tech-feed.events
+      queueName: notification-service
+  persistence:
+    mysql:
+      enabled: false
+      storageClass: ""
+      size: 20Gi
+      existingClaim: ""
+    rabbitmq:
+      enabled: false
+      storageClass: ""
+      size: 8Gi
+      existingClaim: ""
+
+services:
+  frontend:
+    enabled: true
+    replicaCount: 1
+    image:
+      repository: ghcr.io/syuhei0519/tech-news-hub/frontend
+      tag: latest
+      pullPolicy: IfNotPresent
+    imagePullSecrets: []
+    podAnnotations: {}
+    extraLabels: {}
+    service:
+      type: ClusterIP
+      port: 5173
+    containerPort: 5173
+    resources: {}
+    command: []
+    args: []
+    ingress:
+      enabled: true
+      className: ""
+      annotations: {}
+      hosts:
+        - host: tech-feed-hub.local
+          paths:
+            - path: /
+              pathType: Prefix
+      tls: []
+    config:
+      apiBaseUrl: /
+      proxyTarget: ""
+    probes:
+      liveness:
+        path: /
+        initialDelaySeconds: 15
+        periodSeconds: 15
+        timeoutSeconds: 2
+        failureThreshold: 3
+      readiness:
+        path: /
+        initialDelaySeconds: 5
+        periodSeconds: 10
+        timeoutSeconds: 2
+        failureThreshold: 3
+    extraEnv: []
+    extraSecretEnv: []
+
+  apiGateway:
+    enabled: true
+    replicaCount: 1
+    image:
+      repository: ghcr.io/syuhei0519/tech-news-hub/api-gateway
+      tag: latest
+      pullPolicy: IfNotPresent
+    imagePullSecrets: []
+    podAnnotations: {}
+    extraLabels: {}
+    service:
+      type: ClusterIP
+      port: 8080
+    containerPort: 8080
+    resources: {}
+    command: []
+    args: []
+    ingress:
+      enabled: true
+      className: ""
+      annotations: {}
+      hosts:
+        - host: api.tech-feed-hub.local
+          paths:
+            - path: /
+              pathType: Prefix
+      tls: []
+    config:
+      jwtSecret: local-dev-secret
+    probes:
+      liveness:
+        path: /health
+        initialDelaySeconds: 10
+        periodSeconds: 15
+        timeoutSeconds: 2
+        failureThreshold: 3
+      readiness:
+        path: /health
+        initialDelaySeconds: 5
+        periodSeconds: 10
+        timeoutSeconds: 2
+        failureThreshold: 3
+    extraEnv: []
+    extraSecretEnv: []
+
+  articleService:
+    enabled: true
+    replicaCount: 1
+    image:
+      repository: ghcr.io/syuhei0519/tech-news-hub/article-service
+      tag: latest
+      pullPolicy: IfNotPresent
+    imagePullSecrets: []
+    podAnnotations: {}
+    extraLabels: {}
+    service:
+      type: ClusterIP
+      port: 8081
+    containerPort: 8081
+    resources: {}
+    command: []
+    args: []
+    ingress:
+      enabled: false
+      className: ""
+      annotations: {}
+      hosts: []
+      tls: []
+    probes:
+      liveness:
+        path: /health
+        initialDelaySeconds: 10
+        periodSeconds: 15
+        timeoutSeconds: 2
+        failureThreshold: 3
+      readiness:
+        path: /health
+        initialDelaySeconds: 5
+        periodSeconds: 10
+        timeoutSeconds: 2
+        failureThreshold: 3
+    extraEnv: []
+    extraSecretEnv: []
+
+  collectorService:
+    enabled: true
+    replicaCount: 1
+    image:
+      repository: ghcr.io/syuhei0519/tech-news-hub/collector-service
+      tag: latest
+      pullPolicy: IfNotPresent
+    imagePullSecrets: []
+    podAnnotations: {}
+    extraLabels: {}
+    service:
+      type: ClusterIP
+      port: 8082
+    containerPort: 8082
+    resources: {}
+    command: []
+    args: []
+    ingress:
+      enabled: false
+      className: ""
+      annotations: {}
+      hosts: []
+      tls: []
+    schedule: ""
+    probes:
+      liveness:
+        path: /health
+        initialDelaySeconds: 10
+        periodSeconds: 15
+        timeoutSeconds: 2
+        failureThreshold: 3
+      readiness:
+        path: /health
+        initialDelaySeconds: 5
+        periodSeconds: 10
+        timeoutSeconds: 2
+        failureThreshold: 3
+    extraEnv: []
+    extraSecretEnv: []
+
+  notificationService:
+    enabled: true
+    replicaCount: 1
+    image:
+      repository: ghcr.io/syuhei0519/tech-news-hub/notification-service
+      tag: latest
+      pullPolicy: IfNotPresent
+    imagePullSecrets: []
+    podAnnotations: {}
+    extraLabels: {}
+    service:
+      type: ClusterIP
+      port: 8083
+    containerPort: 8083
+    resources: {}
+    command: []
+    args: []
+    ingress:
+      enabled: false
+      className: ""
+      annotations: {}
+      hosts: []
+      tls: []
+    probes:
+      liveness:
+        path: /health
+        initialDelaySeconds: 10
+        periodSeconds: 15
+        timeoutSeconds: 2
+        failureThreshold: 3
+      readiness:
+        path: /health
+        initialDelaySeconds: 5
+        periodSeconds: 10
+        timeoutSeconds: 2
+        failureThreshold: 3
+    extraEnv: []
+    extraSecretEnv: []


### PR DESCRIPTION
## 概要

- `deployments/k8s/charts/app` に app 向け umbrella Helm Chart を追加し、`frontend` / `api-gateway` / `article-service` / `collector-service` / `notification-service` を values から有効化できるようにした
- kind と Proxmox の差分を `values-kind.yaml` / `values-proxmox.yaml` に分離し、image / ingress / resources / replica / Secret 参照の切り替え土台を揃えた
- Closes #62

## 背景 / 目的

- Phase 5 の kind / Helm / Argo CD 整備に向けて、kind 固有値を chart 本体へ埋め込まない app-only chart の骨格が必要だった
- Phase 6 の Proxmox 実クラスタ移行を見据え、registry-aware な image 設定、ingress host/TLS、storage class などを values 差分として追加しやすい状態にしておきたかった

## 変更内容

- `deployments/k8s/charts/app` に `Chart.yaml`、共通 `values.yaml`、環境別 `values-kind.yaml` / `values-proxmox.yaml`、helper、各 app service の template を追加
- 各 service で `image.repository` / `image.tag` / `image.pullPolicy` / `imagePullSecrets`、`replicaCount`、`resources`、`ingress`、probe、Secret 参照を values から制御できるようにした
- app 間依存は `global.dependencies.*Url` と Secret 参照で表現し、MySQL / RabbitMQ 自体はこの issue の非対象として chart 管理対象から外した
- `deployments/k8s/README.md` を更新し、chart 配下のディレクトリ構成、共通 values と環境別 values の境界、Phase 6 で追加予定の差分項目を明記した

## 影響範囲

- infra: `deployments/k8s` の Helm chart / values / README
- docs: Kubernetes 配下の運用ドキュメント
- frontend / api-gateway / collector-service / article-service / notification-service: Kubernetes 上でのデプロイ設定のみ

## 検証

- [ ] `go test ./...`
- [ ] `npm run build`
- [ ] `docker compose config -q`
- [x] その他:
  - `docker run --rm -v /home/syuhei0519/work/app:/work -w /work alpine/helm:3.15.4 lint deployments/k8s/charts/app`
  - `docker run --rm -v /home/syuhei0519/work/app:/work -w /work alpine/helm:3.15.4 template tech-feed-hub deployments/k8s/charts/app -f deployments/k8s/charts/app/values.yaml -f deployments/k8s/charts/app/values-kind.yaml`
  - `docker run --rm -v /home/syuhei0519/work/app:/work -w /work alpine/helm:3.15.4 template tech-feed-hub deployments/k8s/charts/app -f deployments/k8s/charts/app/values.yaml -f deployments/k8s/charts/app/values-proxmox.yaml`

## API / DB / Infra への影響

- [ ] API を変更した
- [ ] DB schema を変更した
- [ ] Compose を変更した
- [x] Kubernetes / Helm を変更した
- [ ] 大きな影響はない

## ドキュメント

- [ ] 必要に応じて `RULES.md` を更新した
- [x] 関連する `docs/` を更新した
- [ ] ドキュメント更新は不要

## リスク / 注意点

- この chart は app-only であり、MySQL / RabbitMQ のインストール自動化や Secret 実値の供給は別管理前提
- `persistence` は Phase 6 の infra 連携に備えた interface として values に置いており、今回の template では PVC resource をまだ生成しない
- この環境では `/snap/bin/helm` が応答しなかったため、Helm 検証は Docker 上の `alpine/helm:3.15.4` で実施した

## 補足

- collector は現状実装に合わせて `Deployment` のままにし、CronJob 化に備えた `schedule` だけ values に予約している
- Phase 6 では `storageClass`、host、TLS、replica、`nodeSelector`、`tolerations`、`affinity`、external secret 化などを values 追加で吸収しやすい前提にしている